### PR TITLE
feat: improve error message when `llama.cpp` source is not downloaded

### DIFF
--- a/src/cli/commands/BuildCommand.ts
+++ b/src/cli/commands/BuildCommand.ts
@@ -1,10 +1,11 @@
 import process from "process";
 import {CommandModule} from "yargs";
 import chalk from "chalk";
+import fs from "fs-extra";
 import {compileLlamaCpp} from "../../utils/compileLLamaCpp.js";
 import withOra from "../../utils/withOra.js";
 import {clearTempFolder} from "../../utils/clearTempFolder.js";
-import {defaultLlamaCppCudaSupport, defaultLlamaCppMetalSupport} from "../../config.js";
+import {defaultLlamaCppCudaSupport, defaultLlamaCppMetalSupport, llamaCppDirectory} from "../../config.js";
 
 type BuildCommand = {
     arch?: string,
@@ -43,6 +44,11 @@ export const BuildCommand: CommandModule<object, BuildCommand> = {
 };
 
 export async function BuildLlamaCppCommand({arch, nodeTarget, metal, cuda}: BuildCommand) {
+    if (!(await fs.pathExists(llamaCppDirectory))) {
+        console.log(chalk.red('llama.cpp is not downloaded. Please run "node-llama-cpp download" first'));
+        process.exit(1);
+    }
+
     if (metal && process.platform === "darwin") {
         console.log(`${chalk.yellow("Metal:")} enabled`);
     }

--- a/src/cli/commands/BuildCommand.ts
+++ b/src/cli/commands/BuildCommand.ts
@@ -65,7 +65,7 @@ export async function BuildLlamaCppCommand({arch, nodeTarget, metal, cuda}: Buil
         await compileLlamaCpp({
             arch: arch ? arch : undefined,
             nodeTarget: nodeTarget ? nodeTarget : undefined,
-            setUsedBingFlag: true,
+            setUsedBinFlag: true,
             metal,
             cuda
         });

--- a/src/cli/commands/DownloadCommand.ts
+++ b/src/cli/commands/DownloadCommand.ts
@@ -165,7 +165,7 @@ export async function DownloadLlamaCppCommand({
         await compileLlamaCpp({
             arch: arch ? arch : undefined,
             nodeTarget: nodeTarget ? nodeTarget : undefined,
-            setUsedBingFlag: true,
+            setUsedBinFlag: true,
             metal,
             cuda
         });

--- a/src/llamaEvaluator/LlamaGrammar.ts
+++ b/src/llamaEvaluator/LlamaGrammar.ts
@@ -26,7 +26,7 @@ export class LlamaGrammar {
 
         const grammarFile = path.join(grammarsFolder, type + ".gbnf");
 
-        if (await fs.exists(grammarFile)) {
+        if (await fs.pathExists(grammarFile)) {
             const grammar = await fs.readFile(grammarFile, "utf8");
             return new LlamaGrammar({grammar});
         }

--- a/src/utils/compileLLamaCpp.ts
+++ b/src/utils/compileLLamaCpp.ts
@@ -15,7 +15,7 @@ export async function compileLlamaCpp({
     arch?: string, nodeTarget?: string, setUsedBinFlag?: boolean, metal?: boolean, cuda?: boolean
 }) {
     try {
-        if (!(await fs.exists(llamaCppDirectory))) {
+        if (!(await fs.pathExists(llamaCppDirectory))) {
             throw new Error(`"${llamaCppDirectory}" directory does not exist`);
         }
 
@@ -46,12 +46,12 @@ export async function compileLlamaCpp({
 
         await spawnCommand("npm", ["run", "-s", "node-gyp-llama", "--", "configure", "--arch=" + arch, "--target=" + nodeTarget, "--", "-f", "compile_commands_json"], __dirname, nodeGypEnv);
 
-        if (await fs.exists(path.join(llamaDirectory, "Release", "compile_commands.json"))) {
+        if (await fs.pathExists(path.join(llamaDirectory, "Release", "compile_commands.json"))) {
             await fs.move(
                 path.join(llamaDirectory, "Release", "compile_commands.json"),
                 path.join(llamaDirectory, "compile_commands.json")
             );
-        } else if (await fs.exists(path.join(llamaDirectory, "Debug", "compile_commands.json"))) {
+        } else if (await fs.pathExists(path.join(llamaDirectory, "Debug", "compile_commands.json"))) {
             await fs.move(
                 path.join(llamaDirectory, "Debug", "compile_commands.json"),
                 path.join(llamaDirectory, "compile_commands.json")
@@ -78,7 +78,7 @@ export async function compileLlamaCpp({
 export async function getCompiledLlamaCppBinaryPath() {
     const modulePath = path.join(__dirname, "..", "..", "llama", "build", "Release", "llama.node");
 
-    if (await fs.exists(modulePath))
+    if (await fs.pathExists(modulePath))
         return modulePath;
 
     return null;

--- a/src/utils/compileLLamaCpp.ts
+++ b/src/utils/compileLLamaCpp.ts
@@ -10,9 +10,9 @@ import {spawnCommand} from "./spawnCommand.js";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export async function compileLlamaCpp({
-    arch = process.arch, nodeTarget = process.version, setUsedBingFlag = true, metal = false, cuda = false
+    arch = process.arch, nodeTarget = process.version, setUsedBinFlag: setUsedBinFlagArg = true, metal = false, cuda = false
 }: {
-    arch?: string, nodeTarget?: string, setUsedBingFlag?: boolean, metal?: boolean, cuda?: boolean
+    arch?: string, nodeTarget?: string, setUsedBinFlag?: boolean, metal?: boolean, cuda?: boolean
 }) {
     try {
         if (!(await fs.exists(llamaCppDirectory))) {
@@ -64,11 +64,11 @@ export async function compileLlamaCpp({
 
         await spawnCommand("npm", ["run", "-s", "node-gyp-llama-build", "--", "--arch=" + arch, "--target=" + nodeTarget], __dirname, nodeGypEnv);
 
-        if (setUsedBingFlag) {
+        if (setUsedBinFlagArg) {
             await setUsedBinFlag("localBuildFromSource");
         }
     } catch (err) {
-        if (setUsedBingFlag)
+        if (setUsedBinFlagArg)
             await setUsedBinFlag("prebuiltBinaries");
 
         throw err;

--- a/src/utils/getBin.ts
+++ b/src/utils/getBin.ts
@@ -25,7 +25,7 @@ export async function getPrebuildBinPath(): Promise<string | null> {
         for (const nodeVersion of nodeVersions) {
             const binPath = createPath(platform, arch, nodeVersion);
 
-            if (await fs.exists(binPath))
+            if (await fs.pathExists(binPath))
                 return binPath;
         }
 

--- a/src/utils/getBin.ts
+++ b/src/utils/getBin.ts
@@ -53,9 +53,9 @@ export async function getPrebuildBinPath(): Promise<string | null> {
 }
 
 export async function loadBin(): Promise<LlamaCppNodeModule> {
-    const usedBingFlag = await getUsedBinFlag();
+    const usedBinFlag = await getUsedBinFlag();
 
-    if (usedBingFlag === "prebuiltBinaries") {
+    if (usedBinFlag === "prebuiltBinaries") {
         const prebuildBinPath = await getPrebuildBinPath();
 
         if (prebuildBinPath == null) {

--- a/src/utils/getGrammarsFolder.ts
+++ b/src/utils/getGrammarsFolder.ts
@@ -3,13 +3,15 @@ import {llamaBinsGrammarsDirectory, llamaCppGrammarsDirectory} from "../config.j
 import {getUsedBinFlag} from "./usedBinFlag.js";
 
 export async function getGrammarsFolder() {
-    const usedBingFlag = await getUsedBinFlag();
+    const usedBinFlag = await getUsedBinFlag();
 
     if (usedBingFlag === "localBuildFromSource") {
         if (await fs.exists(llamaCppGrammarsDirectory))
+    if (usedBinFlag === "localBuildFromSource") {
             return llamaCppGrammarsDirectory;
     } else if (usedBingFlag === "prebuiltBinaries") {
         if (await fs.exists(llamaBinsGrammarsDirectory))
+    } else if (usedBinFlag === "prebuiltBinaries") {
             return llamaBinsGrammarsDirectory;
         else if (await fs.exists(llamaCppGrammarsDirectory))
             return llamaCppGrammarsDirectory;

--- a/src/utils/getGrammarsFolder.ts
+++ b/src/utils/getGrammarsFolder.ts
@@ -5,15 +5,13 @@ import {getUsedBinFlag} from "./usedBinFlag.js";
 export async function getGrammarsFolder() {
     const usedBinFlag = await getUsedBinFlag();
 
-    if (usedBingFlag === "localBuildFromSource") {
-        if (await fs.exists(llamaCppGrammarsDirectory))
     if (usedBinFlag === "localBuildFromSource") {
+        if (await fs.pathExists(llamaCppGrammarsDirectory))
             return llamaCppGrammarsDirectory;
-    } else if (usedBingFlag === "prebuiltBinaries") {
-        if (await fs.exists(llamaBinsGrammarsDirectory))
     } else if (usedBinFlag === "prebuiltBinaries") {
+        if (await fs.pathExists(llamaBinsGrammarsDirectory))
             return llamaBinsGrammarsDirectory;
-        else if (await fs.exists(llamaCppGrammarsDirectory))
+        else if (await fs.pathExists(llamaCppGrammarsDirectory))
             return llamaCppGrammarsDirectory;
     }
 


### PR DESCRIPTION
### Description of change
* Improved error message when `llama.cpp` source is not downloaded
* Typo fixes
* Replaced `fs.exists` with `fs.pathExists`

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/withcatai/node-llama-cpp/blob/master/CONTRIBUTING.md)
