### PR TITLE
fix: move default to the last in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,22 +18,22 @@
   ],
   "exports": {
     ".": {
-      "default": "./dist/index.js",
       "import": "./dist/index.js",
       "node": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./commands": {
-      "default": "./dist/commands.js",
       "import": "./dist/commands.js",
       "node": "./dist/commands.js",
-      "types": "./dist/commands.d.ts"
+      "types": "./dist/commands.d.ts",
+      "default": "./dist/commands.js"
     },
     "./commands.js": {
-      "default": "./dist/commands.js",
       "import": "./dist/commands.js",
       "node": "./dist/commands.js",
-      "types": "./dist/commands.d.ts"
+      "types": "./dist/commands.d.ts",
+      "default": "./dist/commands.js"
     }
   },
   "engines": {


### PR DESCRIPTION
### Description of change

This fixes #30 

The issue is specific to Next.js (or any project that use Webpack, I think), where `default` export must be specified last in package.json. The fix simply moves it to the last.

![スクリーンショット 2023-09-02 12 44 25](https://github.com/withcatai/node-llama-cpp/assets/101444904/c7024373-477c-4f6e-9d00-39034c80bc3e)

### Pull-Request Checklist

<!--
  Please make sure to review and check all the following items:

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change N/A
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits and pull request title follow conventions explained in [CONTRIBUTING.md](https://github.com/withcatai/node-llama-cpp/blob/master/CONTRIBUTING.md) (PRs that do not follow this convention will not be merged)
