### PR TITLE
fix: handle stop words remainder properly in a chat session

### DIFF
--- a/src/llamaEvaluator/LlamaChatSession.ts
+++ b/src/llamaEvaluator/LlamaChatSession.ts
@@ -164,7 +164,6 @@ export class LlamaChatSession {
                 } else {
                     stopStringIndexes[stopStringIndex] = 0;
                     localShouldSkipTokenEvent = false;
-                    break;
                 }
             }
 

--- a/src/llamaEvaluator/LlamaContext.ts
+++ b/src/llamaEvaluator/LlamaContext.ts
@@ -29,11 +29,14 @@ export class LlamaContext {
         return this._ctx.encode(text);
     }
 
-    public decode(tokens: Uint32Array): string {
+    public decode(tokens: Uint32Array | Token[]): string {
         if (tokens.length === 0)
             return "";
 
-        return this._ctx.decode(tokens);
+        if (tokens instanceof Uint32Array)
+            return this._ctx.decode(tokens);
+
+        return this._ctx.decode(Uint32Array.from(tokens));
     }
 
     public get prependBos() {


### PR DESCRIPTION
### Description of change
* fix: detect stop words that don't start with the token string
* fix: handle stop words remainder properly in a chat session
* feat: support decoding a token array instead of only a `Uint32Array`

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits and pull request title follow conventions explained in [CONTRIBUTING.md](https://github.com/withcatai/node-llama-cpp/blob/master/CONTRIBUTING.md) (PRs that do not follow this convention will not be merged)
