### PR TITLE
fix: load image urls properly also outside GitHub

### DIFF
--- a/.config/typedoc.css
+++ b/.config/typedoc.css
@@ -214,21 +214,21 @@ h6:not(.tsd-anchor-link, .tsd-returns-title) > a:hover:before {
     margin-top: 16px;
 }
 
-img[src="assets/logo.roundEdges.png"],
-img[src="assets/logo.png"] {
+img[src$="assets/logo.roundEdges.png"],
+img[src$="assets/logo.png"] {
     box-shadow: 0px 4px 12px 0px rgb(0 0 0 / 16%), 0px 8px 64px 0px rgb(0 0 0 / 24%);
     border-radius: 14px;
 }
 
-div[align="center"] > img[alt="Star please"][src="assets/star.please.roundEdges.png"] ~ p[align="right"],
-div[align="center"] > img[alt="Star please"][src="assets/star.please.png"] ~ p[align="right"] {
+div[align="center"] > img[alt="Star please"][src$="assets/star.please.roundEdges.png"] ~ p[align="right"],
+div[align="center"] > img[alt="Star please"][src$="assets/star.please.png"] ~ p[align="right"] {
     max-width: 360px;
 }
-div[align="center"] > img[alt="Star please"][src="assets/star.please.roundEdges.png"] ~ p[align="right"]>*,
-div[align="center"] > img[alt="Star please"][src="assets/star.please.png"] ~ p[align="right"]>* {
+div[align="center"] > img[alt="Star please"][src$="assets/star.please.roundEdges.png"] ~ p[align="right"]>*,
+div[align="center"] > img[alt="Star please"][src$="assets/star.please.png"] ~ p[align="right"]>* {
     display: none;
 }
-div[align="center"] > img[alt="Star please"][src="assets/star.please.roundEdges.png"] ~ p[align="right"]>:first-of-type,
-div[align="center"] > img[alt="Star please"][src="assets/star.please.png"] ~ p[align="right"]>:first-of-type {
+div[align="center"] > img[alt="Star please"][src$="assets/star.please.roundEdges.png"] ~ p[align="right"]>:first-of-type,
+div[align="center"] > img[alt="Star please"][src$="assets/star.please.png"] ~ p[align="right"]>:first-of-type {
     display: block;
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-    <img alt="node-llama-cpp Logo" src="assets/logo.roundEdges.png" width="360px" />
+    <img alt="node-llama-cpp Logo" src="https://media.githubusercontent.com/media/withcatai/node-llama-cpp/master/assets/logo.roundEdges.png" width="360px" />
     <h1>Node Llama.cpp</h1>
     <p>Node.js bindings for llama.cpp</p>
     <sub>Pre-built bindings are provided with a fallback to building from source with node-gyp</sub>
@@ -323,7 +323,7 @@ Options:
 <br />
 
 <div align="center" width="360">
-    <img alt="Star please" src="assets/star.please.roundEdges.png" width="360px" margin="auto" />
+    <img alt="Star please" src="https://media.githubusercontent.com/media/withcatai/node-llama-cpp/master/assets/star.please.roundEdges.png" width="360px" margin="auto" />
     <br/>
     <p align="right">
         <i>If you like this repo, star it ✨</i>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "prebuild": "rm -rf ./dist ./tsconfig.tsbuildinfo",
     "build": "tsc --build tsconfig.json --force",
     "addPostinstallScript": "npm pkg set scripts.postinstall=\"node ./dist/cli/cli.js postinstall\"",
-    "generate-docs": "typedoc && cp -r ./assets/*.png ./docs/assets/",
+    "generate-docs": "typedoc",
     "prewatch": "rm -rf ./dist ./tsconfig.tsbuildinfo",
     "watch": "tsc --build tsconfig.json --watch --force",
     "node-gyp-llama": "cd llama && node-gyp",


### PR DESCRIPTION
### Description of change
fix: load image urls properly also outside GitHub

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits and pull request title follow conventions explained in [CONTRIBUTING.md](https://github.com/withcatai/node-llama-cpp/blob/master/CONTRIBUTING.md) (PRs that do not follow this convention will not be merged)
