### PR TITLE
ci: run workflows also on PRs from forked repos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,15 @@
 name: Build
 on:
   push:
-
+    branches:
+      - master
+  pull_request_target:
+    branches-ignore:
+      - master
+    types:
+      - synchronize
+      - opened
+      - reopened
   workflow_dispatch:
 
 jobs:
@@ -200,7 +208,7 @@ jobs:
 
   release:
     name: Release
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     runs-on: ubuntu-latest
     concurrency: release-${{ github.ref }}
     environment:

--- a/.github/workflows/prLint.yml
+++ b/.github/workflows/prLint.yml
@@ -12,3 +12,4 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: echo "${{github.ref}}"

--- a/.github/workflows/prLint.yml
+++ b/.github/workflows/prLint.yml
@@ -11,5 +11,7 @@ jobs:
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:
+          REF: ${{ github.ref }}
+          REF_NAME: ${{ github.ref_name }}
+          HEAD_REF: ${{ github.head_ref }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: echo "${{github.ref}}"

--- a/.github/workflows/prLint.yml
+++ b/.github/workflows/prLint.yml
@@ -1,6 +1,5 @@
 name: PR Lint
 on:
-  pull_request:
   pull_request_target:
     types: [opened, reopened, edited, synchronize]
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,17 @@
 name: Test
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request_target:
+    branches-ignore:
+      - master
+    types:
+      - synchronize
+      - opened
+      - reopened
+  workflow_dispatch:
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
### Description of change
Make CI workflows also run on PRs opened from forked repos

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits and pull request title follow conventions explained in [CONTRIBUTING.md](https://github.com/withcatai/node-llama-cpp/blob/master/CONTRIBUTING.md) (PRs that do not follow this convention will not be merged)
