### PR TITLE
feat: only build one binary for all node versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,6 @@ jobs:
         if: startsWith(matrix.config.os, 'windows')
         run: |
           choco install ninja cmake
-          call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvarsamd64_arm64.bat"
 
       - name: Install dependencies on ubuntu
         if: startsWith(matrix.config.name, 'Ubuntu Latest GCC')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,7 +149,7 @@ jobs:
           function getArches() {
             switch (process.env.ARTIFACT_NAME) {
               case "win":
-                return ["x64", "arm64"];
+                return ["x64" /*, "arm64" */ ]; // disabled arm64 for now as compilation doesn't work
               case "linux":
                 return ["x64", "arm64", "armv7l", "ppc64le"];
               case "mac":

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,7 @@ jobs:
         if: startsWith(matrix.config.os, 'windows')
         run: |
           choco install ninja cmake
+          call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvarsamd64_arm64.bat"
 
       - name: Install dependencies on ubuntu
         if: startsWith(matrix.config.name, 'Ubuntu Latest GCC')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,19 +130,19 @@ jobs:
             for (const version of data) {
               const majorVersion = Number(version.version.split(".")[0].slice("v".length));
               const versionDate = new Date(version.date);
-          
+              
               if (maxDate != null && versionDate.getTime() > maxDate)
                 continue;
-          
+              
               if (!versions.has(majorVersion)) {
                 versions.set(majorVersion, version.version);
               }
-          
+              
               if (latestVersion === null || majorVersion > latestVersion) {
                 latestVersion = majorVersion;
               }
             }
-          
+            
             return {versions, latestVersion};
           }
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,6 +165,10 @@ jobs:
           const windowsOnArmNodeVersion = latestNodeVersions.get(20);
           const arches = getArches();
           
+          if (nodeVersion == null || windowsOnArmNodeVersion == null) {
+            throw new Error("Could not find node versions");
+          }
+          
           console.log("Building for node version", nodeVersion, "and archs", arches);
           
           await $`mkdir -p llamaBins`;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,31 @@ jobs:
           
           npx zx -y <<'EOF'
           
+          async function getLatestNodeVersions(maxDate) {
+            const res = await fetch("https://nodejs.org/dist/index.json");
+            const data = await res.json();
+            const versions = new Map();
+            let latestVersion = null;
+          
+            for (const version of data) {
+              const majorVersion = Number(version.version.split(".")[0].slice("v".length));
+              const versionDate = new Date(version.date);
+          
+              if (maxDate != null && versionDate.getTime() > maxDate)
+                continue;
+          
+              if (!versions.has(majorVersion)) {
+                versions.set(majorVersion, version.version);
+              }
+          
+              if (latestVersion === null || majorVersion > latestVersion) {
+                latestVersion = majorVersion;
+              }
+            }
+          
+            return {versions, latestVersion};
+          }
+          
           function getArches() {
             switch (process.env.ARTIFACT_NAME) {
               case "win":
@@ -134,8 +159,10 @@ jobs:
             return ["x64"];
           }
           
-          const nodeVersion = 18;
-          const windowsOnArmNodeVersion = 20;
+          const {versions: latestNodeVersions} = await getLatestNodeVersions(Date.now() - 1000 * 60 * 60 * 24 * 14);
+          
+          const nodeVersion = latestNodeVersions.get(18);
+          const windowsOnArmNodeVersion = latestNodeVersions.get(20);
           const arches = getArches();
           
           console.log("Building for node version", nodeVersion, "and archs", arches);

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
             const data = await res.json();
             const versions = new Map();
             let latestVersion = null;
-          
+            
             for (const version of data) {
               const majorVersion = Number(version.version.split(".")[0].slice("v".length));
               const versionDate = new Date(version.date);

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,35 +121,10 @@ jobs:
           
           npx zx -y <<'EOF'
           
-          async function getLatestNodeVersions(maxDate) {
-            const res = await fetch("https://nodejs.org/dist/index.json");
-            const data = await res.json();
-            const versions = new Map();
-            let latestVersion = null;
-            
-            for (const version of data) {
-              const majorVersion = Number(version.version.split(".")[0].slice("v".length));
-              const versionDate = new Date(version.date);
-              
-              if (maxDate != null && versionDate.getTime() > maxDate)
-                continue;
-              
-              if (!versions.has(majorVersion)) {
-                versions.set(majorVersion, version.version);
-              }
-              
-              if (latestVersion === null || majorVersion > latestVersion) {
-                latestVersion = majorVersion;
-              }
-            }
-            
-            return {versions, latestVersion};
-          }
-          
           function getArches() {
             switch (process.env.ARTIFACT_NAME) {
               case "win":
-                return ["x64"];
+                return ["x64", "arm64"];
               case "linux":
                 return ["x64", "arm64", "armv7l", "ppc64le"];
               case "mac":
@@ -159,32 +134,26 @@ jobs:
             return ["x64"];
           }
           
-          const {versions: latestNodeVersions, latestVersion: latestNodeVersion} = await getLatestNodeVersions(Date.now() - 1000 * 60 * 60 * 24 * 14);
-          
-          const minNodeVersion = latestNodeVersion - 4;
-          
-          const nodeVersions = [...latestNodeVersions].reduce((acc, [majorVersion, version]) => {
-            if (majorVersion >= minNodeVersion)
-              acc.push(version);
-            
-            return acc;
-          }, []);
+          const nodeVersion = 18;
+          const windowsOnArmNodeVersion = 20;
           const arches = getArches();
           
-          console.log("Building for node versions", nodeVersions, "and archs", arches);
+          console.log("Building for node version", nodeVersion, "and archs", arches);
           
           await $`mkdir -p llamaBins`;
           
-          for (const nodeVersion of nodeVersions) {
-            for (const arch of arches) {
-              console.log(`Building ${arch} for node ${nodeVersion}`);
-              
-              const majorNodeVersion = parseInt(nodeVersion.slice("v".length))
-              
-              const binName = `${process.env.ARTIFACT_NAME}-${arch}-${majorNodeVersion}`; 
-              await $`node ./dist/cli/cli.js build --arch ${arch} --nodeTarget ${nodeVersion}`;
-              await $`mv ./llama/build/Release ${"./llamaBins/" + binName}`;
+          for (const arch of arches) {
+            let buildNodeVersion = nodeVersion;
+            
+            if (process.env.ARTIFACT_NAME === "win" && arch === "arm64") {
+              buildNodeVersion = windowsOnArmNodeVersion;
             }
+            
+            console.log(`Building ${arch} for node ${buildNodeVersion}`);
+            
+            const binName = `${process.env.ARTIFACT_NAME}-${arch}`; 
+            await $`node ./dist/cli/cli.js build --arch ${arch} --nodeTarget ${buildNodeVersion}`;
+            await $`mv ./llama/build/Release ${"./llamaBins/" + binName}`;
           }
           
           await $`echo "Built binaries:"`;

--- a/llama/CMakeLists.txt
+++ b/llama/CMakeLists.txt
@@ -4,15 +4,6 @@ project ("llama-addon")
 
 if (MSVC)
   add_compile_options(/EHsc)
-  string(TOLOWER "${CMAKE_GENERATOR_PLATFORM}" ADDON_CMAKE_GENERATOR_PLATFORM_LWR)
-
-  if (("${ADDON_CMAKE_GENERATOR_PLATFORM_LWR}" MATCHES "arm64"))
-    add_compile_definitions(__ARM_NEON)
-    add_compile_definitions(__ARM_FEATURE_FMA)
-    add_compile_definitions(__ARM_FEATURE_DOTPROD)
-    # add_compile_definitions(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC) # MSVC doesn't support vdupq_n_f16, vld1q_f16, vst1q_f16
-    add_compile_definitions(__aarch64__) # MSVC defines _M_ARM64 instead
-  endif()
 else()
   add_compile_options(-fexceptions)
 endif()

--- a/llama/CMakeLists.txt
+++ b/llama/CMakeLists.txt
@@ -4,6 +4,15 @@ project ("llama-addon")
 
 if (MSVC)
   add_compile_options(/EHsc)
+  string(TOLOWER "${CMAKE_GENERATOR_PLATFORM}" ADDON_CMAKE_GENERATOR_PLATFORM_LWR)
+
+  if (("${ADDON_CMAKE_GENERATOR_PLATFORM_LWR}" MATCHES "arm64"))
+    add_compile_definitions(__ARM_NEON)
+    add_compile_definitions(__ARM_FEATURE_FMA)
+    add_compile_definitions(__ARM_FEATURE_DOTPROD)
+    # add_compile_definitions(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC) # MSVC doesn't support vdupq_n_f16, vld1q_f16, vst1q_f16
+    add_compile_definitions(__aarch64__) # MSVC defines _M_ARM64 instead
+  endif()
 else()
   add_compile_options(-fexceptions)
 endif()

--- a/src/utils/getBin.ts
+++ b/src/utils/getBin.ts
@@ -14,20 +14,15 @@ import {getCompiledLlamaCppBinaryPath} from "./compileLLamaCpp.js";
 const require = createRequire(import.meta.url);
 
 export async function getPrebuildBinPath(): Promise<string | null> {
-    const majorNodeVersion = parseInt(process.version.slice("v".length));
-    const supportedVersions = [majorNodeVersion, majorNodeVersion - 1];
-
-    function createPath(platform: string, arch: string, nodeVersion: number) {
-        return path.join(llamaBinsDirectory, `${platform}-${arch}-${nodeVersion}/llama-addon.node`);
+    function createPath(platform: string, arch: string) {
+        return path.join(llamaBinsDirectory, `${platform}-${arch}/llama-addon.node`);
     }
 
-    async function resolvePath(platform: string, arch: string, nodeVersions: number[]) {
-        for (const nodeVersion of nodeVersions) {
-            const binPath = createPath(platform, arch, nodeVersion);
+    async function resolvePath(platform: string, arch: string) {
+        const binPath = createPath(platform, arch);
 
-            if (await fs.pathExists(binPath))
-                return binPath;
-        }
+        if (await fs.pathExists(binPath))
+            return binPath;
 
         return null;
     }
@@ -36,14 +31,14 @@ export async function getPrebuildBinPath(): Promise<string | null> {
         switch (process.platform) {
             case "win32":
             case "cygwin":
-                return resolvePath("win", process.arch, supportedVersions);
+                return resolvePath("win", process.arch);
 
             case "linux":
             case "android":
-                return resolvePath("linux", process.arch, supportedVersions);
+                return resolvePath("linux", process.arch);
 
             case "darwin":
-                return resolvePath("mac", process.arch, supportedVersions);
+                return resolvePath("mac", process.arch);
         }
 
         return null;


### PR DESCRIPTION
### Description of change
The current compilation flow produces a binary that uses [N-API](https://nodejs.org/api/n-api.html#n_api_node_api) properly and thus is [ABI-Stable](https://nodejs.org/en/docs/guides/abi-stability), meaning that the binary is compatible with the node.js version it was compiled for (v18) and all subsequent versions.
This means that we only need to compile one binary for each platform and architecture.

This PR makes the result npm module much smaller in size and ensures compatibility with all future node.js versions in terms of binary compatibility.

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits and pull request title follow conventions explained in [CONTRIBUTING.md](https://github.com/withcatai/node-llama-cpp/blob/master/CONTRIBUTING.md) (PRs that do not follow this convention will not be merged)