### PR TITLE
feat: fall back to build from source if prebuilt binary loading fails

### DIFF
--- a/src/utils/getBin.ts
+++ b/src/utils/getBin.ts
@@ -56,7 +56,16 @@ export async function loadBin(): Promise<LlamaCppNodeModule> {
         if (prebuildBinPath == null) {
             console.warn("Prebuild binaries not found, falling back to to locally built binaries");
         } else {
-            return require(prebuildBinPath);
+            try {
+                return require(prebuildBinPath);
+            } catch (err) {
+                console.error(`Failed to load prebuilt binary for platform "${process.platform}" "${process.arch}". Error:`, err);
+                console.info("Falling back to locally built binaries");
+
+                try {
+                    delete require.cache[require.resolve(prebuildBinPath)];
+                } catch (err) {}
+            }
         }
     }
 


### PR DESCRIPTION
### Description of change
* feat: fall back to build from source if prebuilt binary loading fails

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply eslint formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits and pull request title follow conventions explained in [CONTRIBUTING.md](https://github.com/withcatai/node-llama-cpp/blob/master/CONTRIBUTING.md) (PRs that do not follow this convention will not be merged)
