### PR TITLE
fix: make disabling metal on build work

### DIFF
--- a/src/utils/compileLLamaCpp.ts
+++ b/src/utils/compileLLamaCpp.ts
@@ -26,7 +26,7 @@ export async function compileLlamaCpp({
         const cmakeCustomOptions = [];
 
         if ((metal && process.platform === "darwin") || process.env.LLAMA_METAL === "1") cmakeCustomOptions.push("LLAMA_METAL=1");
-        else cmakeCustomOptions.push("LLAMA_METAL=0");
+        else cmakeCustomOptions.push("LLAMA_METAL=OFF");
 
         if (cuda || process.env.LLAMA_CUBLAS === "1") cmakeCustomOptions.push("LLAMA_CUBLAS=1");
         if (process.env.LLAMA_MPI === "1") cmakeCustomOptions.push("LLAMA_MPI=1");


### PR DESCRIPTION
### Description of change
fix: make disabling metal on build work

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply eslint formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits and pull request title follow conventions explained in [CONTRIBUTING.md](https://github.com/withcatai/node-llama-cpp/blob/master/CONTRIBUTING.md) (PRs that do not follow this convention will not be merged)
