### PR TITLE
fix: bugs

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,3 +1,6 @@
 {
-    "extends": ["@commitlint/config-conventional"]
+    "extends": ["@commitlint/config-conventional"],
+    "rules": {
+        "subject-case": [0, "never"]
+    }
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,6 +231,9 @@ jobs:
       - name: Install modules
         run: npm ci
 
+      - name: Build binary
+        run: node ./dist/cli/cli.js build
+
       - name: Run standalone tests
         run: npm run test:standalone
 

--- a/docs/guide/CUDA.md
+++ b/docs/guide/CUDA.md
@@ -23,20 +23,38 @@ To build `node-llama-cpp` with any of these options, set an environment variable
 ### Fix the `Failed to detect a default CUDA architecture` build error
 To fix this issue you have to set the `CUDACXX` environment variable to the path of the `nvcc` compiler.
 
-For example, if you installed CUDA Toolkit 12.2 on Windows, you have to run the following command:
-```bash
-set CUDACXX=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2\bin\nvcc.exe
-```
-
-On Linux, it would be something like this:
-```bash
+For example, if you have installed CUDA Toolkit 12.2, you have to run a command like this:
+::: code-group
+```bash [Linux]
 export CUDACXX=/usr/local/cuda-12.2/bin/nvcc
 ```
+
+```bash [Windows]
+set CUDACXX=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2\bin\nvcc.exe
+```
+:::
 
 Then run the build command again to check whether setting the `CUDACXX` environment variable fixed the issue.
 
 ### Fix the `The CUDA compiler identification is unknown` build error
 The solution to this error is the same as [the solution to the `Failed to detect a default CUDA architecture` error](#fix-the-failed-to-detect-a-default-cuda-architecture-build-error).
+
+### Fix the `A single input file is required for a non-link phase when an outputfile is specified` build error
+To fix this issue you have to set the `CMAKE_GENERATOR_TOOLSET` cmake option to the CUDA home directory, usually already set as the `CUDA_PATH` environment variable.
+
+To do this, set the `NODE_LLAMA_CPP_CMAKE_OPTION_CMAKE_GENERATOR_TOOLSET` environment variable to the path of your CUDA home directory:
+
+::: code-group
+```bash [Linux]
+export NODE_LLAMA_CPP_CMAKE_OPTION_CMAKE_GENERATOR_TOOLSET=$CUDA_PATH
+```
+
+```bash [Windows]
+set NODE_LLAMA_CPP_CMAKE_OPTION_CMAKE_GENERATOR_TOOLSET=%CUDA_PATH%
+```
+:::
+
+Then run the build command again to check whether setting the `CMAKE_GENERATOR_TOOLSET` cmake option fixed the issue.
 
 ## Using `node-llama-cpp` with CUDA
 After you build `node-llama-cpp` with CUDA support, you can use it normally.

--- a/docs/guide/CUDA.md
+++ b/docs/guide/CUDA.md
@@ -35,6 +35,9 @@ export CUDACXX=/usr/local/cuda-12.2/bin/nvcc
 
 Then run the build command again to check whether setting the `CUDACXX` environment variable fixed the issue.
 
+### Fix the `The CUDA compiler identification is unknown` build error
+The solution to this error is the same as [the solution to the `Failed to detect a default CUDA architecture` error](#fix-the-failed-to-detect-a-default-cuda-architecture-build-error).
+
 ## Using `node-llama-cpp` with CUDA
 After you build `node-llama-cpp` with CUDA support, you can use it normally.
 

--- a/docs/guide/building-from-source.md
+++ b/docs/guide/building-from-source.md
@@ -27,6 +27,8 @@ If `cmake` is not installed on your machine, `node-llama-cpp` will automatically
 
 If the build fails, make sure you have the required dependencies of `cmake` installed on your machine. More info is available [here](https://github.com/cmake-js/cmake-js#:~:text=projectRoot/build%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Bstring%5D-,Requirements%3A,-CMake) (you don't have to install `cmake` or `cmake-js`, just the dependencies).
 
+If the build fails on macOS with the error `"/usr/bin/cc" is not able to compile a simple test program`, try running `xcode-select --install` to install the Xcode command line tools.
+
 :::
 
 ## `download` and `build` commands

--- a/docs/guide/cli/build.md
+++ b/docs/guide/cli/build.md
@@ -10,6 +10,10 @@ const commandDoc = docs.build;
 
 {{commandDoc.description}}
 
+::: info
+If the build fails on macOS with the error `"/usr/bin/cc" is not able to compile a simple test program`, try running `xcode-select --install` to install the Xcode command line tools.
+:::
+
 ## Usage
 ```shell-vue
 {{commandDoc.usage}}

--- a/docs/guide/cli/download.md
+++ b/docs/guide/cli/download.md
@@ -20,6 +20,10 @@ This is useful for building from source on machines that aren't connected to the
 
 :::
 
+::: info
+If the build fails on macOS with the error `"/usr/bin/cc" is not able to compile a simple test program`, try running `xcode-select --install` to install the Xcode command line tools.
+:::
+
 ## Usage
 ```shell-vue
 {{commandDoc.usage}}

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -14,6 +14,11 @@ npm install --save node-llama-cpp
 > If binaries are not available for your platform, it'll fallback to download a release of `llama.cpp` and build it from source with `cmake`.
 > To disable this behavior, set the environment variable `NODE_LLAMA_CPP_SKIP_DOWNLOAD` to `true`.
 
+## ESM usage
+`node-llama-cpp` is an [ES module](https://nodejs.org/api/esm.html#modules-ecmascript-modules), so can only use `import` to load it and cannot use `require`.
+
+To make sure you can use it in your project, make sure your `package.json` file has `"type": "module"` in it.
+
 ## CUDA and Metal support
 **Metal:** Metal support is enabled by default on macOS. If you're using a Mac with an Intel chip, [you might want to disable it](./Metal.md).
 

--- a/llama/CMakeLists.txt
+++ b/llama/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13)
 
-project ("llama-addon")
+project("llama-addon" C CXX)
 
 if (MSVC)
   # add_compile_options(/EHsc)

--- a/llama/addon.cpp
+++ b/llama/addon.cpp
@@ -208,13 +208,13 @@ class LLAMAContext : public Napi::ObjectWrap<LLAMAContext> {
     return Napi::String::New(info.Env(), ss.str());
   }
   Napi::Value TokenBos(const Napi::CallbackInfo& info) {
-    return Napi::Number::From(info.Env(), llama_token_bos(ctx));
+    return Napi::Number::From(info.Env(), llama_token_bos(model->model)); // TODO: move this to the model
   }
   Napi::Value TokenEos(const Napi::CallbackInfo& info) {
-    return Napi::Number::From(info.Env(), llama_token_eos(ctx));
+    return Napi::Number::From(info.Env(), llama_token_eos(model->model)); // TODO: move this to the model
   }
   Napi::Value TokenNl(const Napi::CallbackInfo& info) {
-    return Napi::Number::From(info.Env(), llama_token_nl(ctx));
+    return Napi::Number::From(info.Env(), llama_token_nl(model->model)); // TODO: move this to the model
   }
   Napi::Value GetContextSize(const Napi::CallbackInfo& info) {
     return Napi::Number::From(info.Env(), llama_n_ctx(ctx));
@@ -223,7 +223,7 @@ class LLAMAContext : public Napi::ObjectWrap<LLAMAContext> {
     int token = info[0].As<Napi::Number>().Int32Value();
     std::stringstream ss;
 
-    const char* str = llama_token_get_text(ctx, token);
+    const char* str = llama_token_get_text(model->model, token); // TODO: move this to the model
     if (str == nullptr) {
       return info.Env().Undefined();
     }
@@ -377,7 +377,7 @@ class LLAMAContextEvalWorker : Napi::AsyncWorker, Napi::Promise::Deferred {
 
     llama_token_data_array candidates_p = { candidates.data(), candidates.size(), false };
 
-    auto eos_token = llama_token_eos(ctx->ctx);
+    auto eos_token = llama_token_eos(ctx->model->model);
 
     if (use_repeat_penalty && !repeat_penalty_tokens.empty()) {
       llama_sample_repetition_penalties(

--- a/llama/package.json
+++ b/llama/package.json
@@ -1,0 +1,5 @@
+{
+  "binary": {
+    "napi_versions": [7]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "@commitlint/cli": "^17.7.1",
     "@commitlint/config-conventional": "^17.7.0",
     "@semantic-release/exec": "^6.0.3",
-    "@types/bytes": "^3.1.1",
     "@types/cli-progress": "^3.11.0",
     "@types/cross-spawn": "^6.0.2",
     "@types/fs-extra": "^11.0.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,3 +57,8 @@ export const defaultChatSystemPrompt = "You are a helpful, respectful and honest
     "If you don't know the answer to a question, please don't share false information.";
 export const cliBinName = "node-llama-cpp";
 export const npxRunPrefix = "npx --no ";
+
+const documentationUrl = "https://withcatai.github.io/node-llama-cpp";
+export const documentationPageUrls = {
+    CUDA: documentationUrl + "/guide/CUDA"
+} as const;

--- a/src/utils/cmake.ts
+++ b/src/utils/cmake.ts
@@ -35,6 +35,12 @@ export async function getCmakePath() {
 
         if (resolvedPath.toLowerCase().endsWith(".cmd"))
             resolvedPath = (await getBinFromWindowCmd(resolvedPath, "cmake.exe")) ?? "";
+        else if (resolvedPath.toLowerCase().endsWith(".ps1")) {
+            const cmdFilePath = resolvedPath.slice(0, -".ps1".length) + ".cmd";
+
+            if (await fs.pathExists(cmdFilePath))
+                resolvedPath = (await getBinFromWindowCmd(cmdFilePath, "cmake.exe")) ?? "";
+        }
 
         if (resolvedPath !== "")
             return resolvedPath;

--- a/src/utils/compileLLamaCpp.ts
+++ b/src/utils/compileLLamaCpp.ts
@@ -2,7 +2,10 @@ import path from "path";
 import {fileURLToPath} from "url";
 import process from "process";
 import fs from "fs-extra";
-import {customCmakeOptionsEnvVarPrefix, llamaCppDirectory, llamaDirectory, llamaToolchainsDirectory} from "../config.js";
+import chalk from "chalk";
+import {
+    customCmakeOptionsEnvVarPrefix, documentationPageUrls, llamaCppDirectory, llamaDirectory, llamaToolchainsDirectory
+} from "../config.js";
 import {clearLlamaBuild} from "./clearLlamaBuild.js";
 import {setUsedBinFlag} from "./usedBinFlag.js";
 import {spawnCommand} from "./spawnCommand.js";
@@ -86,6 +89,13 @@ export async function compileLlamaCpp({
     } catch (err) {
         if (setUsedBinFlagArg)
             await setUsedBinFlag("prebuiltBinaries");
+
+        if (cuda)
+            console.info("\n" +
+                chalk.grey("[node-llama-cpp] ") +
+                chalk.yellow("To resolve errors related to CUDA compilation, see the CUDA guide: ") +
+                documentationPageUrls.CUDA
+            );
 
         throw err;
     } finally {

--- a/src/utils/gbnfJson/terminals/GbnfStringValue.ts
+++ b/src/utils/gbnfJson/terminals/GbnfStringValue.ts
@@ -11,14 +11,16 @@ export class GbnfStringValue extends GbnfTerminal {
 
     override getGrammar(): string {
         return [
-            "\"",
+            '"',
+            '\\"',
             this.value
                 .replaceAll("\\", "\\\\")
                 .replaceAll("\t", "\\t")
                 .replaceAll("\r", "\\r")
                 .replaceAll("\n", "\\n")
                 .replaceAll('"', "\\\\" + '\\"'),
-            "\""
+            '\\"',
+            '"'
         ].join("");
     }
 }

--- a/test/standalone/llamaEvaluator/LlamaGrammar.test.ts
+++ b/test/standalone/llamaEvaluator/LlamaGrammar.test.ts
@@ -104,7 +104,7 @@ describe("grammar for JSON schema", () => {
         };
 
         expect(grammar.grammar).toMatchInlineSnapshot(`
-          "root ::= \\"{\\" whitespace-new-lines-rule \\"message\\" \\":\\" [ ]? rule0 \\",\\" whitespace-new-lines-rule \\"numberOfWordsInMessage\\" \\":\\" [ ]? integer-number-rule \\",\\" whitespace-new-lines-rule \\"feelingGoodPercentage\\" \\":\\" [ ]? fractional-number-rule \\",\\" whitespace-new-lines-rule \\"feelingGood\\" \\":\\" [ ]? boolean-rule \\",\\" whitespace-new-lines-rule \\"feelingOverall\\" \\":\\" [ ]? rule5 \\",\\" whitespace-new-lines-rule \\"verbsInMessage\\" \\":\\" [ ]? rule6 whitespace-new-lines-rule \\"}\\" [\\\\n] [\\\\n] [\\\\n] [\\\\n] [\\\\n]*
+          "root ::= \\"{\\" whitespace-new-lines-rule \\"\\\\\\"message\\\\\\"\\" \\":\\" [ ]? rule0 \\",\\" whitespace-new-lines-rule \\"\\\\\\"numberOfWordsInMessage\\\\\\"\\" \\":\\" [ ]? integer-number-rule \\",\\" whitespace-new-lines-rule \\"\\\\\\"feelingGoodPercentage\\\\\\"\\" \\":\\" [ ]? fractional-number-rule \\",\\" whitespace-new-lines-rule \\"\\\\\\"feelingGood\\\\\\"\\" \\":\\" [ ]? boolean-rule \\",\\" whitespace-new-lines-rule \\"\\\\\\"feelingOverall\\\\\\"\\" \\":\\" [ ]? rule5 \\",\\" whitespace-new-lines-rule \\"\\\\\\"verbsInMessage\\\\\\"\\" \\":\\" [ ]? rule6 whitespace-new-lines-rule \\"}\\" [\\\\n] [\\\\n] [\\\\n] [\\\\n] [\\\\n]*
           whitespace-new-lines-rule ::= [\\\\n]? [ \\\\t]* [\\\\n]?
           string-rule ::= \\"\\\\\\"\\" ( [^\\"\\\\\\\\] | \\"\\\\\\\\\\" ([\\"\\\\\\\\/bfnrt] | \\"u\\" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]))* \\"\\\\\\"\\"
           null-rule ::= \\"null\\"
@@ -114,8 +114,8 @@ describe("grammar for JSON schema", () => {
           rule1 ::= \\"true\\"
           rule2 ::= \\"false\\"
           boolean-rule ::= ( rule1 | rule2 )
-          rule3 ::= \\"good\\"
-          rule4 ::= \\"bad\\"
+          rule3 ::= \\"\\\\\\"good\\\\\\"\\"
+          rule4 ::= \\"\\\\\\"bad\\\\\\"\\"
           rule5 ::= ( rule3 | rule4 )
           rule7 ::= ( string-rule ) ( \\",\\" whitespace-new-lines-rule string-rule )*
           rule8 ::= ( string-rule )?
@@ -210,7 +210,7 @@ describe("grammar for JSON schema", () => {
           "root ::= \\"[\\" whitespace-new-lines-rule ( rule2 | rule3 ) whitespace-new-lines-rule \\"]\\" [\\\\n] [\\\\n] [\\\\n] [\\\\n] [\\\\n]*
           whitespace-new-lines-rule ::= [\\\\n]? [ \\\\t]* [\\\\n]?
           string-rule ::= \\"\\\\\\"\\" ( [^\\"\\\\\\\\] | \\"\\\\\\\\\\" ([\\"\\\\\\\\/bfnrt] | \\"u\\" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]))* \\"\\\\\\"\\"
-          rule0 ::= \\"{\\" whitespace-new-lines-rule \\"message\\" \\":\\" [ ]? string-rule whitespace-new-lines-rule \\"}\\"
+          rule0 ::= \\"{\\" whitespace-new-lines-rule \\"\\\\\\"message\\\\\\"\\" \\":\\" [ ]? string-rule whitespace-new-lines-rule \\"}\\"
           rule1 ::= ( rule0 | string-rule )
           rule2 ::= ( rule1 ) ( \\",\\" whitespace-new-lines-rule rule1 )*
           rule3 ::= ( rule1 )?"
@@ -297,12 +297,12 @@ describe("grammar for JSON schema", () => {
         };
 
         expect(grammar.grammar).toMatchInlineSnapshot(`
-          "root ::= \\"{\\" whitespace-new-lines-rule \\"onlyPositiveText\\" \\":\\" [ ]? \\"true\\" \\",\\" whitespace-new-lines-rule \\"onlyNegativeText\\" \\":\\" [ ]? \\"false\\" \\",\\" whitespace-new-lines-rule \\"onlyVibe\\" \\":\\" [ ]? rule0 \\",\\" whitespace-new-lines-rule \\"onlyNumber\\" \\":\\" [ ]? \\"10\\" \\",\\" whitespace-new-lines-rule \\"worstThing\\" \\":\\" [ ]? null-rule \\",\\" whitespace-new-lines-rule \\"withNewLine\\" \\":\\" [ ]? rule1 \\",\\" whitespace-new-lines-rule \\"withQuotes\\" \\":\\" [ ]? rule2 whitespace-new-lines-rule \\"}\\" [\\\\n] [\\\\n] [\\\\n] [\\\\n] [\\\\n]*
+          "root ::= \\"{\\" whitespace-new-lines-rule \\"\\\\\\"onlyPositiveText\\\\\\"\\" \\":\\" [ ]? \\"true\\" \\",\\" whitespace-new-lines-rule \\"\\\\\\"onlyNegativeText\\\\\\"\\" \\":\\" [ ]? \\"false\\" \\",\\" whitespace-new-lines-rule \\"\\\\\\"onlyVibe\\\\\\"\\" \\":\\" [ ]? rule0 \\",\\" whitespace-new-lines-rule \\"\\\\\\"onlyNumber\\\\\\"\\" \\":\\" [ ]? \\"10\\" \\",\\" whitespace-new-lines-rule \\"\\\\\\"worstThing\\\\\\"\\" \\":\\" [ ]? null-rule \\",\\" whitespace-new-lines-rule \\"\\\\\\"withNewLine\\\\\\"\\" \\":\\" [ ]? rule1 \\",\\" whitespace-new-lines-rule \\"\\\\\\"withQuotes\\\\\\"\\" \\":\\" [ ]? rule2 whitespace-new-lines-rule \\"}\\" [\\\\n] [\\\\n] [\\\\n] [\\\\n] [\\\\n]*
           whitespace-new-lines-rule ::= [\\\\n]? [ \\\\t]* [\\\\n]?
-          rule0 ::= \\"good\\"
+          rule0 ::= \\"\\\\\\"good\\\\\\"\\"
           null-rule ::= \\"null\\"
-          rule1 ::= \\"Hooray!\\\\nYes!\\\\t/\\\\\\\\\\"
-          rule2 ::= \\"The message is \\\\\\\\\\\\\\"Hi!\\\\\\\\\\\\\\".\\""
+          rule1 ::= \\"\\\\\\"Hooray!\\\\nYes!\\\\t/\\\\\\\\\\\\\\"\\"
+          rule2 ::= \\"\\\\\\"The message is \\\\\\\\\\\\\\"Hi!\\\\\\\\\\\\\\".\\\\\\"\\""
         `);
 
         const parsedValue = grammar.parse(JSON.stringify(exampleValidValue));
@@ -374,12 +374,12 @@ describe("grammar for JSON schema", () => {
         };
 
         expect(grammar.grammar).toMatchInlineSnapshot(`
-          "root ::= \\"{\\" whitespace-new-lines-rule \\"onlyPositiveText\\" \\":\\" [ ]? \\"true\\" \\",\\" whitespace-new-lines-rule \\"onlyNegativeText\\" \\":\\" [ ]? \\"false\\" \\",\\" whitespace-new-lines-rule \\"onlyVibe\\" \\":\\" [ ]? rule0 \\",\\" whitespace-new-lines-rule \\"onlyNumber\\" \\":\\" [ ]? \\"10\\" \\",\\" whitespace-new-lines-rule \\"worstThing\\" \\":\\" [ ]? null-rule \\",\\" whitespace-new-lines-rule \\"withNewLine\\" \\":\\" [ ]? rule1 \\",\\" whitespace-new-lines-rule \\"withQuotes\\" \\":\\" [ ]? rule2 whitespace-new-lines-rule \\"}\\" [\\\\n] [\\\\n] [\\\\n] [\\\\n] [\\\\n]*
+          "root ::= \\"{\\" whitespace-new-lines-rule \\"\\\\\\"onlyPositiveText\\\\\\"\\" \\":\\" [ ]? \\"true\\" \\",\\" whitespace-new-lines-rule \\"\\\\\\"onlyNegativeText\\\\\\"\\" \\":\\" [ ]? \\"false\\" \\",\\" whitespace-new-lines-rule \\"\\\\\\"onlyVibe\\\\\\"\\" \\":\\" [ ]? rule0 \\",\\" whitespace-new-lines-rule \\"\\\\\\"onlyNumber\\\\\\"\\" \\":\\" [ ]? \\"10\\" \\",\\" whitespace-new-lines-rule \\"\\\\\\"worstThing\\\\\\"\\" \\":\\" [ ]? null-rule \\",\\" whitespace-new-lines-rule \\"\\\\\\"withNewLine\\\\\\"\\" \\":\\" [ ]? rule1 \\",\\" whitespace-new-lines-rule \\"\\\\\\"withQuotes\\\\\\"\\" \\":\\" [ ]? rule2 whitespace-new-lines-rule \\"}\\" [\\\\n] [\\\\n] [\\\\n] [\\\\n] [\\\\n]*
           whitespace-new-lines-rule ::= [\\\\n]? [ \\\\t]* [\\\\n]?
-          rule0 ::= \\"good\\"
+          rule0 ::= \\"\\\\\\"good\\\\\\"\\"
           null-rule ::= \\"null\\"
-          rule1 ::= \\"Hooray!\\\\nYes!\\\\t/\\\\\\\\\\"
-          rule2 ::= \\"The message is \\\\\\\\\\\\\\"Hi!\\\\\\\\\\\\\\".\\""
+          rule1 ::= \\"\\\\\\"Hooray!\\\\nYes!\\\\t/\\\\\\\\\\\\\\"\\"
+          rule2 ::= \\"\\\\\\"The message is \\\\\\\\\\\\\\"Hi!\\\\\\\\\\\\\\".\\\\\\"\\""
         `);
 
         const parsedValue = grammar.parse(JSON.stringify(exampleValidValue));
@@ -452,12 +452,12 @@ describe("grammar for JSON schema", () => {
         };
 
         expect(grammar.grammar).toMatchInlineSnapshot(`
-          "root ::= \\"{\\" whitespace-new-lines-rule \\"onlyPositiveText\\" \\":\\" [ ]? \\"true\\" \\",\\" whitespace-new-lines-rule \\"onlyNegativeText\\" \\":\\" [ ]? \\"false\\" \\",\\" whitespace-new-lines-rule \\"onlyVibe\\" \\":\\" [ ]? rule0 \\",\\" whitespace-new-lines-rule \\"onlyNumber\\" \\":\\" [ ]? \\"10\\" \\",\\" whitespace-new-lines-rule \\"worstThing\\" \\":\\" [ ]? null-rule \\",\\" whitespace-new-lines-rule \\"withNewLine\\" \\":\\" [ ]? rule1 \\",\\" whitespace-new-lines-rule \\"withQuotes\\" \\":\\" [ ]? rule2 whitespace-new-lines-rule \\"}\\" [\\\\n] [\\\\n] [\\\\n] [\\\\n] [\\\\n]*
+          "root ::= \\"{\\" whitespace-new-lines-rule \\"\\\\\\"onlyPositiveText\\\\\\"\\" \\":\\" [ ]? \\"true\\" \\",\\" whitespace-new-lines-rule \\"\\\\\\"onlyNegativeText\\\\\\"\\" \\":\\" [ ]? \\"false\\" \\",\\" whitespace-new-lines-rule \\"\\\\\\"onlyVibe\\\\\\"\\" \\":\\" [ ]? rule0 \\",\\" whitespace-new-lines-rule \\"\\\\\\"onlyNumber\\\\\\"\\" \\":\\" [ ]? \\"10\\" \\",\\" whitespace-new-lines-rule \\"\\\\\\"worstThing\\\\\\"\\" \\":\\" [ ]? null-rule \\",\\" whitespace-new-lines-rule \\"\\\\\\"withNewLine\\\\\\"\\" \\":\\" [ ]? rule1 \\",\\" whitespace-new-lines-rule \\"\\\\\\"withQuotes\\\\\\"\\" \\":\\" [ ]? rule2 whitespace-new-lines-rule \\"}\\" [\\\\n] [\\\\n] [\\\\n] [\\\\n] [\\\\n]*
           whitespace-new-lines-rule ::= [\\\\n]? [ \\\\t]* [\\\\n]?
-          rule0 ::= \\"good\\"
+          rule0 ::= \\"\\\\\\"good\\\\\\"\\"
           null-rule ::= \\"null\\"
-          rule1 ::= \\"Hooray!\\\\nYes!\\\\t/\\\\\\\\\\"
-          rule2 ::= \\"The message is \\\\\\\\\\\\\\"Hi!\\\\\\\\\\\\\\".\\""
+          rule1 ::= \\"\\\\\\"Hooray!\\\\nYes!\\\\t/\\\\\\\\\\\\\\"\\"
+          rule2 ::= \\"\\\\\\"The message is \\\\\\\\\\\\\\"Hi!\\\\\\\\\\\\\\".\\\\\\"\\""
         `);
 
         const parsedValue = grammar.parse(JSON.stringify(exampleValidValue));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+    test: {
+        threads: false
+    }
+});


### PR DESCRIPTION
### Description of change
* feat: adapt to the latest `llama.cpp` interface
* feat: print helpful information to help resolve a clone issue when it happens
* feat: print helpful information to help resolve build issues related to CUDA
* feat: make portable cmake on Windows more stable
* feat: update `CMakeLists.txt` to match `llama.cpp` better
* fix: do not download redundant node headers
* fix: improve cmake custom options handling
* fix: do not set `CMAKE_GENERATOR_TOOLSET` for CUDA
* fix: do not fetch information from GitHub when using a local git bundle
* fix: GBNF JSON schema string const formatting
* docs: document a solution to a compilation problem on macOS
* docs: document more CUDA build error solutions
* docs: explain about ES modules in the getting started guide
* chore: update `.commitlintrc.json`
* chore: remove redundant dependency

Fixes #78 
Fixes #79
Fixes #58
Reintroduces #74 - added documentation on how to resolve it ([link](https://withcatai.github.io/node-llama-cpp/guide/CUDA#fix-the-a-single-input-file-is-required-for-a-non-link-phase-when-an-outputfile-is-specified-build-error))

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply eslint formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits and pull request title follow conventions explained in [pull request guidelines](https://withcatai.github.io/node-llama-cpp/guide/contributing) (PRs that do not follow this convention will not be merged)
