### PR TITLE
fix package.json to use module instead of main

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "node-llama-cpp",
   "version": "0.1.0",
   "description": "Run AI models locally on your machine with node.js bindings for llama.cpp. Force a JSON schema on the model output on the generation level",
-  "main": "dist/index.js",
+  "module": "dist/index.js",
   "type": "module",
   "types": "./dist/index.d.ts",
   "bin": {


### PR DESCRIPTION
fix: build

* esmodules should be using module and not main the package.json root

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended to correct.

  In some cases, it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged, it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all the following items:

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply eslint formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits and pull request title follow conventions explained in [pull request guidelines](https://withcatai.github.io/node-llama-cpp/guide/contributing) (PRs that do not follow this convention will not be merged)
