### PR TITLE
get embedding for text

### DIFF
--- a/llama/usedBin.json
+++ b/llama/usedBin.json
@@ -1,3 +1,3 @@
 {
-    "use": "prebuiltBinaries"
+    "use": "localBuildFromSource"
 }

--- a/src/llamaEvaluator/LlamaContext.ts
+++ b/src/llamaEvaluator/LlamaContext.ts
@@ -121,6 +121,10 @@ export class LlamaContext {
         return this._ctx.decode(Uint32Array.from(tokens));
     }
 
+    public embeddings(text: string): Uint32Array {
+        return this._ctx.embeddings(text);
+    }
+
     public get prependBos() {
         return this._prependBos;
     }

--- a/src/utils/getBin.ts
+++ b/src/utils/getBin.ts
@@ -122,6 +122,7 @@ export type LLAMAContext = {
         threads?: number,
     }): LLAMAContext,
     encode(text: string): Uint32Array,
+    embeddings(text: string): Uint32Array,
     eval(tokens: Uint32Array, options?: {
         temperature?: number,
         topK?: number,


### PR DESCRIPTION
### Description of change

Fixes #123 

Implements a method that returns the embedding of a text.
It is an adapted copy of the embedding.cpp from llama.cpp/examples

### Pull-Request Checklist

<!--
  Please make sure to review and check all the following items:

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ x] Code is up-to-date with the `master` branch
- [ x] `npm run format` to apply eslint formatting
- [ x] `npm run test` passes with this change
- [ x] This pull request links relevant issues as `Fixes #0000`
- [ N/A] There are new or updated unit tests validating the change
- [ N/A ] Documentation has been updated to reflect this change
- [ x] The new commits and pull request title follow conventions explained in [pull request guidelines](https://withcatai.github.io/node-llama-cpp/guide/contributing) (PRs that do not follow this convention will not be merged)
