### PR TITLE
feat(minor): add `--batchSize` and `--promptFile` options to the `chat` CLI command

### DIFF
--- a/src/cli/commands/ChatCommand.ts
+++ b/src/cli/commands/ChatCommand.ts
@@ -220,7 +220,7 @@ export const ChatCommand: CommandModule<object, ChatCommand> = {
                 model, systemInfo, systemPrompt, prompt, promptFile, wrapper, contextSize, batchSize,
                 grammar, jsonSchemaGrammarFile, threads, temperature, topK, topP,
                 gpuLayers, lastTokensRepeatPenalty, repeatPenalty, penalizeRepeatingNewLine,
-                repeatFrequencyPenalty, repeatPresencePenalty, maxTokens, noHistory, printTimings,
+                repeatFrequencyPenalty, repeatPresencePenalty, maxTokens, noHistory, printTimings
             });
         } catch (err) {
             console.error(err);


### PR DESCRIPTION
Adds feature parity with llama.cpp's `main`

`--promptFile` for testing of larger initial prompts including embedding text
`--batchSize` to override the default `batchSize`