### PR TITLE
fix: don't block a node process from exiting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,7 +250,7 @@ jobs:
 
   model-dependent-tests:
     name: Model dependent tests
-    runs-on: macos-13
+    runs-on: macos-14
     needs:
       - build
     steps:

--- a/src/bindings/getLlama.ts
+++ b/src/bindings/getLlama.ts
@@ -122,9 +122,13 @@ export async function getLlama(type: "lastBuild", lastBuildOptions?: LastBuildOp
 export async function getLlama(options?: LlamaOptions | "lastBuild", lastBuildOptions?: LastBuildOptions) {
     if (options === "lastBuild") {
         const lastBuildInfo = await getLastBuildInfo();
+        const getLlamaOptions: LlamaOptions = {
+            logLevel: lastBuildOptions?.logLevel ?? defaultLlamaCppDebugLogs,
+            logger: lastBuildOptions?.logger ?? Llama.defaultConsoleLogger
+        };
 
         if (lastBuildInfo == null)
-            return getLlamaForOptions({});
+            return getLlamaForOptions(getLlamaOptions);
 
         const localBuildFolder = path.join(llamaLocalBuildBinsDirectory, lastBuildInfo.folderName);
         const localBuildBinPath = await getLocalBuildBinaryPath(lastBuildInfo.folderName);
@@ -148,7 +152,7 @@ export async function getLlama(options?: LlamaOptions | "lastBuild", lastBuildOp
             }
         }
 
-        return getLlamaForOptions({});
+        return getLlamaForOptions(getLlamaOptions);
     }
 
     return getLlamaForOptions(options ?? {});

--- a/src/cli/commands/ChatCommand.ts
+++ b/src/cli/commands/ChatCommand.ts
@@ -346,6 +346,8 @@ async function RunChat({
         chatWrapper: chatWrapper
     });
 
+    await new Promise((accept) => setTimeout(accept, 0)); // wait for logs to finish printing
+
     if (grammarArg != "text" && jsonSchemaGrammarFilePath != null)
         console.warn(chalk.yellow("Both `grammar` and `jsonSchemaGrammarFile` were specified. `jsonSchemaGrammarFile` will be used."));
 
@@ -448,7 +450,7 @@ async function RunChat({
         console.log();
 
         if (printTimings)
-            context.printTimings();
+            await context.printTimings();
     }
 }
 

--- a/src/evaluator/LlamaContext/LlamaContext.ts
+++ b/src/evaluator/LlamaContext/LlamaContext.ts
@@ -322,8 +322,9 @@ export class LlamaContext {
         });
     }
 
-    public printTimings() {
+    public async printTimings() {
         this._ctx.printTimings();
+        await new Promise((accept) => setTimeout(accept, 0)); // wait for the logs to finish printing
     }
 
     /** @internal */

--- a/src/utils/withOra.ts
+++ b/src/utils/withOra.ts
@@ -1,4 +1,5 @@
 import ora from "ora";
+import {getConsoleLogPrefix} from "./getConsoleLogPrefix.js";
 
 export default async function withOra<T>(
     message: string | {
@@ -8,7 +9,14 @@ export default async function withOra<T>(
     },
     callback: () => Promise<T>
 ): Promise<T> {
-    const spinner = ora(typeof message === "string" ? message : message.loading);
+    const spinner = ora({
+        prefixText: getConsoleLogPrefix(),
+        ...(
+            typeof message === "string"
+                ? {text: message} satisfies Parameters<typeof ora>[0]
+                : message
+        )
+    });
 
     spinner.start();
 


### PR DESCRIPTION
### Description of change
* fix: don't block a node process from exiting
* fix: respect `logLevel` and `logger` params when using `"lastBuild"`
* fix: print logs on the same event loop cycle

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply eslint formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits and pull request title follow conventions explained in [pull request guidelines](https://withcatai.github.io/node-llama-cpp/guide/contributing) (PRs that do not follow this convention will not be merged)
