### PR TITLE
feat: render markdown in the Electron example

### DIFF
--- a/templates/electron-typescript-react/electron-builder.ts
+++ b/templates/electron-typescript-react/electron-builder.ts
@@ -60,22 +60,13 @@ export default {
         artifactName: "${name}.macOS.${version}.${arch}.${ext}"
     },
     win: {
-        target: [
-            {
-                target: "nsis",
-                arch: [
-                    "x64",
-                    "arm64"
-                ]
-            },
-            {
-                target: "appx",
-                arch: [
-                    "x64",
-                    "arm64"
-                ]
-            }
-        ],
+        target: [{
+            target: "nsis",
+            arch: [
+                "x64",
+                "arm64"
+            ]
+        }],
 
         artifactName: "${name}.Windows.${version}.${arch}.${ext}"
     },
@@ -99,8 +90,7 @@ export default {
         }, {
             target: "snap",
             arch: [
-                "x64",
-                "arm64"
+                "x64"
             ]
         }, {
             target: "deb",

--- a/templates/electron-typescript-react/electron/rpc/llmRpc.ts
+++ b/templates/electron-typescript-react/electron/rpc/llmRpc.ts
@@ -28,7 +28,16 @@ export class ElectronLlmRpc {
             if (!res.canceled && res.filePaths.length > 0) {
                 llmState.state = {
                     ...llmState.state,
-                    selectedModelFilePath: path.resolve(res.filePaths[0])
+                    selectedModelFilePath: path.resolve(res.filePaths[0]),
+                    chatSession: {
+                        loaded: false,
+                        generatingResult: false,
+                        simplifiedChat: [],
+                        draftPrompt: {
+                            prompt: llmState.state.chatSession.draftPrompt.prompt,
+                            completion: ""
+                        }
+                    }
                 };
 
                 if (!llmState.state.llama.loaded)

--- a/templates/electron-typescript-react/package.json
+++ b/templates/electron-typescript-react/package.json
@@ -24,12 +24,15 @@
   "dependencies": {
     "birpc": "^0.2.17",
     "classnames": "^2.5.1",
+    "highlight.js": "^11.9.0",
     "lifecycle-utils": "^1.4.1",
+    "markdown-it": "^14.1.0",
     "node-llama-cpp": "file:../..",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@types/markdown-it": "^14.1.1",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^7.12.0",

--- a/templates/electron-typescript-react/src/App/App.tsx
+++ b/templates/electron-typescript-react/src/App/App.tsx
@@ -158,7 +158,7 @@ export function App() {
             />
         }
         <InputRow
-            disabled={!state.model.loaded}
+            disabled={!state.model.loaded || !state.contextSequence.loaded}
             stopGeneration={
                 generatingResult
                     ? stopActivePrompt
@@ -167,7 +167,6 @@ export function App() {
             onPromptInput={onPromptInput}
             sendPrompt={sendPrompt}
             generatingResult={generatingResult}
-            contextSequenceLoaded={state.contextSequence.loaded}
             autocompleteInputDraft={state.chatSession.draftPrompt.prompt}
             autocompleteCompletion={state.chatSession.draftPrompt.completion}
         />

--- a/templates/electron-typescript-react/src/App/components/ChatHistory/ChatHistory.css
+++ b/templates/electron-typescript-react/src/App/components/ChatHistory/ChatHistory.css
@@ -6,43 +6,51 @@
     overflow: auto;
     padding: 24px 0px;
 
-    > .message.user {
-        align-self: flex-end;
-        background-color: var(--user-message-background-color);
-        padding: 8px 12px;
-        border-radius: 12px;
-        margin-bottom: 12px;
-        margin-inline-start: 48px;
-        margin-inline-end: 12px;
-        color: var(--user-message-text-color);
-        white-space: pre-wrap;
+    > .message {
+        &.user {
+            align-self: flex-end;
+            background-color: var(--user-message-background-color);
+            padding: 8px 12px;
+            border-radius: 12px;
+            margin-bottom: 12px;
+            margin-inline-start: 48px;
+            margin-inline-end: 12px;
+            color: var(--user-message-text-color);
 
-        &:not(:first-child) {
-            margin-top: 36px;
-        }
-    }
-
-    > .message.model {
-        align-self: flex-start;
-        margin-inline-end: 48px;
-        padding-inline-start: 24px;
-        white-space: pre-wrap;
-
-        &.active {
-            &:after {
-                content: "";
-                position: static;
-                display: inline-block;
-                background-color: currentColor;
-                width: 8px;
-                height: 8px;
-                translate: 0px -2px;
-                border-radius: 9999px;
-                margin-inline-start: 8px;
-                vertical-align: middle;
-
-                animation: activeModelMessageIndicator 2s infinite ease-in-out;
+            &:not(:first-child) {
+                margin-top: 36px;
             }
+        }
+
+        &.model {
+            align-self: flex-start;
+            margin-inline-end: 48px;
+            padding-inline-start: 24px;
+
+            &.active {
+                &:after {
+                    content: "";
+                    position: static;
+                    display: inline-block;
+                    background-color: currentColor;
+                    width: 8px;
+                    height: 8px;
+                    translate: 0px -2px;
+                    border-radius: 9999px;
+                    margin-inline-start: 8px;
+                    vertical-align: middle;
+
+                    animation: activeModelMessageIndicator 2s infinite ease-in-out;
+                }
+            }
+        }
+
+        > :first-child {
+            margin-top: 0px;
+        }
+
+        > :last-child {
+            margin-bottom: 0px;
         }
     }
 }

--- a/templates/electron-typescript-react/src/App/components/ChatHistory/ChatHistory.tsx
+++ b/templates/electron-typescript-react/src/App/components/ChatHistory/ChatHistory.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import {LlmState} from "../../../../electron/state/llmState.ts";
+import {MarkdownContent} from "../MarkdownContent/MarkdownContent.js";
 
 import "./ChatHistory.css";
 
@@ -10,14 +11,14 @@ export function ChatHistory({simplifiedChat, generatingResult}: ChatHistoryProps
             simplifiedChat.map((item, index) => {
                 if (item.type === "model") {
                     const isActive = index === simplifiedChat.length - 1 && generatingResult;
-                    return <div key={index} className={classNames("message", "model", isActive && "active")}>
+                    return <MarkdownContent key={index} className={classNames("message", "model", isActive && "active")}>
                         {item.message}
-                    </div>;
+                    </MarkdownContent>;
 
                 } else if (item.type === "user")
-                    return <div key={index} className="message user">
+                    return <MarkdownContent key={index} className="message user">
                         {item.message}
-                    </div>;
+                    </MarkdownContent>;
 
                 return null;
             })

--- a/templates/electron-typescript-react/src/App/components/InputRow/InputRow.tsx
+++ b/templates/electron-typescript-react/src/App/components/InputRow/InputRow.tsx
@@ -7,8 +7,7 @@ import "./InputRow.css";
 
 
 export function InputRow({
-    disabled = false, stopGeneration, sendPrompt, onPromptInput, autocompleteInputDraft, autocompleteCompletion, generatingResult,
-    contextSequenceLoaded
+    disabled = false, stopGeneration, sendPrompt, onPromptInput, autocompleteInputDraft, autocompleteCompletion, generatingResult
 }: InputRowProps) {
     const [inputText, setInputText] = useState<string>("");
     const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -95,7 +94,7 @@ export function InputRow({
                 className="input"
                 autoComplete="off"
                 spellCheck
-                disabled={disabled || !contextSequenceLoaded}
+                disabled={disabled}
                 onScroll={resizeInput}
                 placeholder={
                     autocompleteText === ""
@@ -120,7 +119,7 @@ export function InputRow({
         </button>
         <button
             className="sendButton"
-            disabled={disabled || !contextSequenceLoaded || inputText === "" || generatingResult}
+            disabled={disabled || inputText === "" || generatingResult}
             onClick={submitPrompt}
         >
             <AddMessageIconSVG className="icon" />
@@ -135,6 +134,5 @@ type InputRowProps = {
     onPromptInput?(currentText: string): void,
     autocompleteInputDraft?: string,
     autocompleteCompletion?: string,
-    generatingResult: boolean,
-    contextSequenceLoaded: boolean
+    generatingResult: boolean
 };

--- a/templates/electron-typescript-react/src/App/components/MarkdownContent/MarkdownContent.css
+++ b/templates/electron-typescript-react/src/App/components/MarkdownContent/MarkdownContent.css
@@ -1,0 +1,234 @@
+/* Only style code blocks */
+pre > code {
+    display: block;
+    background-color: var(--code-block-background-color);
+    padding: 0.8em 1.2em;
+    border-radius: 0.4em;
+    font-size: 1.2em;
+    overflow-x: auto;
+    user-select: all;
+
+    @media (prefers-color-scheme: light) {
+        /*!
+          Theme: GitHub
+          Description: Light theme as seen on github.com
+          Author: github.com
+          Maintainer: @Hirse
+          Updated: 2021-05-15
+
+          Outdated base version: https://github.com/primer/github-syntax-light
+          Current colors taken from GitHub's CSS
+        */
+        .hljs {
+            color: #24292e;
+            background: #ffffff
+        }
+        .hljs-doctag,
+        .hljs-keyword,
+        .hljs-meta .hljs-keyword,
+        .hljs-template-tag,
+        .hljs-template-variable,
+        .hljs-type,
+        .hljs-variable.language_ {
+            /* prettylights-syntax-keyword */
+            color: #d73a49
+        }
+        .hljs-title,
+        .hljs-title.class_,
+        .hljs-title.class_.inherited__,
+        .hljs-title.function_ {
+            /* prettylights-syntax-entity */
+            color: #6f42c1
+        }
+        .hljs-attr,
+        .hljs-attribute,
+        .hljs-literal,
+        .hljs-meta,
+        .hljs-number,
+        .hljs-operator,
+        .hljs-variable,
+        .hljs-selector-attr,
+        .hljs-selector-class,
+        .hljs-selector-id {
+            /* prettylights-syntax-constant */
+            color: #005cc5
+        }
+        .hljs-regexp,
+        .hljs-string,
+        .hljs-meta .hljs-string {
+            /* prettylights-syntax-string */
+            color: #032f62
+        }
+        .hljs-built_in,
+        .hljs-symbol {
+            /* prettylights-syntax-variable */
+            color: #e36209
+        }
+        .hljs-comment,
+        .hljs-code,
+        .hljs-formula {
+            /* prettylights-syntax-comment */
+            color: #6a737d
+        }
+        .hljs-name,
+        .hljs-quote,
+        .hljs-selector-tag,
+        .hljs-selector-pseudo {
+            /* prettylights-syntax-entity-tag */
+            color: #22863a
+        }
+        .hljs-subst {
+            /* prettylights-syntax-storage-modifier-import */
+            color: #24292e
+        }
+        .hljs-section {
+            /* prettylights-syntax-markup-heading */
+            color: #005cc5;
+            font-weight: bold
+        }
+        .hljs-bullet {
+            /* prettylights-syntax-markup-list */
+            color: #735c0f
+        }
+        .hljs-emphasis {
+            /* prettylights-syntax-markup-italic */
+            color: #24292e;
+            font-style: italic
+        }
+        .hljs-strong {
+            /* prettylights-syntax-markup-bold */
+            color: #24292e;
+            font-weight: bold
+        }
+        .hljs-addition {
+            /* prettylights-syntax-markup-inserted */
+            color: #22863a;
+            background-color: #f0fff4
+        }
+        .hljs-deletion {
+            /* prettylights-syntax-markup-deleted */
+            color: #b31d28;
+            background-color: #ffeef0
+        }
+        .hljs-char.escape_,
+        .hljs-link,
+        .hljs-params,
+        .hljs-property,
+        .hljs-punctuation,
+        .hljs-tag {
+            /* purposely ignored */
+        }
+    }
+
+    @media (prefers-color-scheme: dark) {
+        /*!
+          Theme: GitHub Dark
+          Description: Dark theme as seen on github.com
+          Author: github.com
+          Maintainer: @Hirse
+          Updated: 2021-05-15
+
+          Outdated base version: https://github.com/primer/github-syntax-dark
+          Current colors taken from GitHub's CSS
+        */
+        .hljs {
+            color: #c9d1d9;
+            background: #0d1117
+        }
+        .hljs-doctag,
+        .hljs-keyword,
+        .hljs-meta .hljs-keyword,
+        .hljs-template-tag,
+        .hljs-template-variable,
+        .hljs-type,
+        .hljs-variable.language_ {
+            /* prettylights-syntax-keyword */
+            color: #ff7b72
+        }
+        .hljs-title,
+        .hljs-title.class_,
+        .hljs-title.class_.inherited__,
+        .hljs-title.function_ {
+            /* prettylights-syntax-entity */
+            color: #d2a8ff
+        }
+        .hljs-attr,
+        .hljs-attribute,
+        .hljs-literal,
+        .hljs-meta,
+        .hljs-number,
+        .hljs-operator,
+        .hljs-variable,
+        .hljs-selector-attr,
+        .hljs-selector-class,
+        .hljs-selector-id {
+            /* prettylights-syntax-constant */
+            color: #79c0ff
+        }
+        .hljs-regexp,
+        .hljs-string,
+        .hljs-meta .hljs-string {
+            /* prettylights-syntax-string */
+            color: #a5d6ff
+        }
+        .hljs-built_in,
+        .hljs-symbol {
+            /* prettylights-syntax-variable */
+            color: #ffa657
+        }
+        .hljs-comment,
+        .hljs-code,
+        .hljs-formula {
+            /* prettylights-syntax-comment */
+            color: #8b949e
+        }
+        .hljs-name,
+        .hljs-quote,
+        .hljs-selector-tag,
+        .hljs-selector-pseudo {
+            /* prettylights-syntax-entity-tag */
+            color: #7ee787
+        }
+        .hljs-subst {
+            /* prettylights-syntax-storage-modifier-import */
+            color: #c9d1d9
+        }
+        .hljs-section {
+            /* prettylights-syntax-markup-heading */
+            color: #1f6feb;
+            font-weight: bold
+        }
+        .hljs-bullet {
+            /* prettylights-syntax-markup-list */
+            color: #f2cc60
+        }
+        .hljs-emphasis {
+            /* prettylights-syntax-markup-italic */
+            color: #c9d1d9;
+            font-style: italic
+        }
+        .hljs-strong {
+            /* prettylights-syntax-markup-bold */
+            color: #c9d1d9;
+            font-weight: bold
+        }
+        .hljs-addition {
+            /* prettylights-syntax-markup-inserted */
+            color: #aff5b4;
+            background-color: #033a16
+        }
+        .hljs-deletion {
+            /* prettylights-syntax-markup-deleted */
+            color: #ffdcd7;
+            background-color: #67060c
+        }
+        .hljs-char.escape_,
+        .hljs-link,
+        .hljs-params,
+        .hljs-property,
+        .hljs-punctuation,
+        .hljs-tag {
+            /* purposely ignored */
+        }
+    }
+}

--- a/templates/electron-typescript-react/src/App/components/MarkdownContent/MarkdownContent.tsx
+++ b/templates/electron-typescript-react/src/App/components/MarkdownContent/MarkdownContent.tsx
@@ -1,0 +1,40 @@
+import {useLayoutEffect, useRef} from "react";
+import markdownit from "markdown-it";
+import hljs from "highlight.js";
+
+import "./MarkdownContent.css";
+
+const md = markdownit({
+    highlight(str, lang): string {
+        if (hljs.getLanguage(lang) != null) {
+            try {
+                return hljs.highlight(str, {language: lang}).value;
+            } catch (err) {
+                // do nothing
+            }
+        }
+
+        return hljs.highlightAuto(str).value;
+    }
+});
+
+export function MarkdownContent({children, className}: MarkdownContentProps) {
+    const divRef = useRef<HTMLDivElement>(null);
+
+    useLayoutEffect(() => {
+        if (divRef.current == null)
+            return;
+
+        divRef.current.innerHTML = md.render(children ?? "");
+    }, [children]);
+
+    return <div
+        className={className}
+        ref={divRef}
+    />;
+}
+
+type MarkdownContentProps = {
+    className?: string,
+    children: string
+};

--- a/templates/electron-typescript-react/src/index.css
+++ b/templates/electron-typescript-react/src/index.css
@@ -42,6 +42,8 @@
     --actions-block-background-color: light-dark(rgba(0 0 0 / 4%), rgba(0 0 0 / 16%));
     --actions-block-border-color: light-dark(rgba(0 0 0 / 4%), rgba(0 0 0 / 16%));
     --actions-block-box-shadow: 0px 4px 8px 0px rgba(0 0 0 / 2%), 0px 6px 24px 0px rgba(0 0 0 / 8%);
+
+    --code-block-background-color: light-dark(rgba(0 0 0 / 4%), rgba(0 0 0 / 16%));
 }
 
 body {


### PR DESCRIPTION
### Description of change
* feat: render markdown in the Electron example
* fix: only build practical targets by default in the Electron example

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply eslint formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits and pull request title follow conventions explained in [pull request guidelines](https://withcatai.github.io/node-llama-cpp/guide/contributing) (PRs that do not follow this convention will not be merged)
