### PR TITLE
fix: revert `electron-builder` version used in Electron template

### DIFF
--- a/templates/electron-typescript-react/package.json
+++ b/templates/electron-typescript-react/package.json
@@ -41,7 +41,7 @@
     "@typescript-eslint/parser": "^7.12.0",
     "@vitejs/plugin-react": "^4.3.1",
     "electron": "^32.1.0",
-    "electron-builder": "^25.0.5",
+    "electron-builder": "^24.13.3",
     "eslint": "^8.57.0",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jsdoc": "^48.2.9",


### PR DESCRIPTION
### Description of change
* fix: revert `electron-builder` version used in Electron template

There's an issue with Electron Builder `>=25.0.1` where building an app produces an asar archive with a `node_modules` tree that uses wrong module versions, which causes the packaged app to behave differently than it does on dev mode, and very frequently crash or not load at all.
I'm downgrading the version of `electron-builder` used in the template electron app until this is fixed.

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply eslint formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits and pull request title follow conventions explained in [pull request guidelines](https://node-llama-cpp.withcat.ai/guide/contributing) (PRs that do not follow this convention will not be merged)
