### PR TITLE
build: fix release job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -502,7 +502,7 @@ jobs:
           GH_RELEASE_REF: ${{ github.ref }}
         run: |
           echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > ~/.npmrc
-          export DRY_RUN_RESULT="$(cat ./semanticReleaseDryRunReleaseResult.json)"
+          export DRY_RUN_RESULT_FILE_PATH="$(pwd)/semanticReleaseDryRunReleaseResult.json"
           
           npx semantic-release
       - name: Set npm package url to GITHUB_OUTPUT

--- a/.releaserc.ts
+++ b/.releaserc.ts
@@ -1,4 +1,5 @@
 import {createRequire} from "module";
+import fs from "fs-extra";
 import {getBinariesGithubRelease} from "./dist/bindings/utils/binariesGithubRelease.js";
 import {cliBinName, defaultLlamaCppGitHubRepo} from "./dist/config.js";
 
@@ -65,11 +66,13 @@ const config: Omit<GlobalConfig, "repositoryUrl" | "tagFormat"> = {
 
 function getDryRunResult() {
     try {
-        const dryRunResultEnvVarValue = process.env.DRY_RUN_RESULT;
+        const dryRunResultEnvVarValue = process.env.DRY_RUN_RESULT_FILE_PATH;
         if (dryRunResultEnvVarValue == null)
             return null;
 
-        const res: SemanticReleaseDryRunResult = JSON.parse(dryRunResultEnvVarValue);
+        const dryRunResultValue = fs.readFileSync(dryRunResultEnvVarValue, "utf8");
+
+        const res: SemanticReleaseDryRunResult = JSON.parse(dryRunResultValue);
         if (res === false)
             return null;
 


### PR DESCRIPTION
### Description of change
* build: fix release job

There's an issue where if there's an environment variable with a value that's too long, calling any `npx` command fails.

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply eslint formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits and pull request title follow conventions explained in [pull request guidelines](https://node-llama-cpp.withcat.ai/guide/contributing) (PRs that do not follow this convention will not be merged)
