### PR TITLE
feat: Export getLlamaForOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import {DisposedError} from "lifecycle-utils";
 import {Llama} from "./bindings/Llama.js";
-import {getLlama, type LlamaOptions, type LastBuildOptions} from "./bindings/getLlama.js";
+import {getLlama, getLlamaForOptions, type LlamaOptions, type LastBuildOptions} from "./bindings/getLlama.js";
 import {getLlamaGpuTypes} from "./bindings/utils/getLlamaGpuTypes.js";
 import {NoBinaryFoundError} from "./bindings/utils/NoBinaryFoundError.js";
 import {
@@ -120,6 +120,7 @@ import type {TemplateChatWrapperSegmentsOptions} from "./chatWrappers/generic/ut
 export {
     Llama,
     getLlama,
+    getLlamaForOptions,
     getLlamaGpuTypes,
     type LlamaOptions,
     type LastBuildOptions,


### PR DESCRIPTION
Add getLlamaForOptions to the list of exported functions

### Description of change

This PR exports `getLllamaForOptions` from the main import. We've been [using this in Aibrow](https://github.com/axonzeta/aibrow/blob/9fd30d3030150c5b3e789ce65c775bde5074658b/src/native/main/APIHandler/LlmSessionAPIHandler.ts#L105) to hard check for GPU engine support at runtime. For example...

```ts
import { getLlamaForOptions } from 'node-llama-cpp'

try {
  await getLlamaForOptions({
    gpu: false, // 'cuda' 'vulkan' 'metal' ...
    build: 'never',
    vramPadding: 0
  },
  { skipLlamaInit: true })
  console.log('Supported')
} catch (ex) {
  console.log('Not supported')
}
```

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended to correct.

  In some cases, it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged, it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all the following items:

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply eslint formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [ ] There are new or updated unit tests validating the change N/A
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits and pull request title follow conventions explained in [pull request guidelines](https://node-llama-cpp.withcat.ai/guide/contributing) (PRs that do not follow this convention will not be merged)
