### PR TITLE
fix: Allow importing when using a SEA binary

### DIFF
--- a/src/bindings/getLlama.ts
+++ b/src/bindings/getLlama.ts
@@ -1,5 +1,6 @@
 import process from "process";
 import path from "path";
+import sea from "node:sea";
 import console from "console";
 import {createRequire} from "module";
 import {
@@ -914,6 +915,9 @@ function getShouldTestBinaryBeforeLoading({
     platformInfo: BinaryPlatformInfo,
     buildMetadata: BuildMetadataFile
 }) {
+    if (sea.isSea()) {
+        return false;
+    }
     if (platform === "linux") {
         if (isPrebuiltBinary)
             return true;


### PR DESCRIPTION
testBindingBinary would throw when using a node-llama-cpp in a SEA binary. Add an exclusion to getShouldTestBinaryBeforeLoading to check for this and skip the test.

### Description of change

[As requested](https://github.com/axonzeta/node-llama-cpp/commit/938dfac8931c0fa6c6b368bc43eaeccb70667458#r157544694) bringing this into the main repo as PR. Not sure if this is the *right* way to address this, but it fixed it when we were trying to bundle node-llama-cpp into a [SEA binary](https://nodejs.org/api/single-executable-applications.html).

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended to correct.

  In some cases, it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged, it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all the following items:

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply eslint formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [ ] There are new or updated unit tests validating the change N/A
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits and pull request title follow conventions explained in [pull request guidelines](https://node-llama-cpp.withcat.ai/guide/contributing) (PRs that do not follow this convention will not be merged)
