### PR TITLE
fix(`JinjaTemplateChatWrapper`): first function call prefix detection

### DIFF
--- a/llama/addon/AddonContext.cpp
+++ b/llama/addon/AddonContext.cpp
@@ -587,7 +587,7 @@ Napi::Value AddonContext::DisposeSequence(const Napi::CallbackInfo& info) {
 
     int32_t sequenceId = info[0].As<Napi::Number>().Int32Value();
 
-    bool result = llama_kv_self_seq_rm(ctx, sequenceId, -1, -1);
+    bool result = llama_memory_seq_rm(llama_get_memory(ctx), sequenceId, -1, -1);
 
     if (!result) {
         Napi::Error::New(info.Env(), "Failed to dispose sequence").ThrowAsJavaScriptException();
@@ -606,7 +606,7 @@ Napi::Value AddonContext::RemoveTokenCellsFromSequence(const Napi::CallbackInfo&
     int32_t startPos = info[1].As<Napi::Number>().Int32Value();
     int32_t endPos = info[2].As<Napi::Number>().Int32Value();
 
-    bool result = llama_kv_self_seq_rm(ctx, sequenceId, startPos, endPos);
+    bool result = llama_memory_seq_rm(llama_get_memory(ctx), sequenceId, startPos, endPos);
 
     return Napi::Boolean::New(info.Env(), result);
 }
@@ -621,7 +621,7 @@ Napi::Value AddonContext::ShiftSequenceTokenCells(const Napi::CallbackInfo& info
     int32_t endPos = info[2].As<Napi::Number>().Int32Value();
     int32_t shiftDelta = info[3].As<Napi::Number>().Int32Value();
 
-    llama_kv_self_seq_add(ctx, sequenceId, startPos, endPos, shiftDelta);
+    llama_memory_seq_add(llama_get_memory(ctx), sequenceId, startPos, endPos, shiftDelta);
 
     return info.Env().Undefined();
 }
@@ -634,7 +634,7 @@ Napi::Value AddonContext::GetSequenceKvCacheMinPosition(const Napi::CallbackInfo
     int32_t sequenceId = info[0].As<Napi::Number>().Int32Value();
 
 
-    const auto minPosition = llama_kv_self_seq_pos_min(ctx, sequenceId);
+    const auto minPosition = llama_memory_seq_pos_min(llama_get_memory(ctx), sequenceId);
 
     return Napi::Number::New(info.Env(), minPosition);
 }
@@ -647,7 +647,7 @@ Napi::Value AddonContext::GetSequenceKvCacheMaxPosition(const Napi::CallbackInfo
     int32_t sequenceId = info[0].As<Napi::Number>().Int32Value();
 
 
-    const auto maxPosition = llama_kv_self_seq_pos_max(ctx, sequenceId);
+    const auto maxPosition = llama_memory_seq_pos_max(llama_get_memory(ctx), sequenceId);
 
     return Napi::Number::New(info.Env(), maxPosition);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "ignore": "^7.0.4",
         "ipull": "^3.9.2",
         "is-unicode-supported": "^2.1.0",
-        "lifecycle-utils": "^2.0.0",
+        "lifecycle-utils": "^2.0.1",
         "log-symbols": "^7.0.0",
         "nanoid": "^5.1.5",
         "node-addon-api": "^8.3.1",
@@ -11548,9 +11548,9 @@
       }
     },
     "node_modules/lifecycle-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lifecycle-utils/-/lifecycle-utils-2.0.0.tgz",
-      "integrity": "sha512-KIkV6NeD2n0jZnO+fdIGKI5Or7alyhb6UTFzeaqf6EnE5y3pdK821+kd7yOMBUL/sPYhHU5ny74J0QKslLikGw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lifecycle-utils/-/lifecycle-utils-2.0.1.tgz",
+      "integrity": "sha512-jVso5WXIHfDL7Lf9sCRbLbPwgpoha5qUPgi+RMNVIMuOcb0nJ9Qr0r1OXbqLaxzBUQBhN8jYy92RLSk2OGJ6Cg==",
       "license": "MIT"
     },
     "node_modules/lines-and-columns": {

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "ignore": "^7.0.4",
     "ipull": "^3.9.2",
     "is-unicode-supported": "^2.1.0",
-    "lifecycle-utils": "^2.0.0",
+    "lifecycle-utils": "^2.0.1",
     "log-symbols": "^7.0.0",
     "nanoid": "^5.1.5",
     "node-addon-api": "^8.3.1",

--- a/src/chatWrappers/QwenChatWrapper.ts
+++ b/src/chatWrappers/QwenChatWrapper.ts
@@ -247,7 +247,9 @@ export class QwenChatWrapper extends ChatWrapper {
     public static override _getOptionConfigurationsToTestIfCanSupersedeJinjaTemplate(): ChatWrapperJinjaMatchConfiguration<typeof this> {
         return [
             [{}, {}, {_requireFunctionCallSettingsExtraction: true}],
-            [{_lineBreakBeforeFunctionCallPrefix: true}, {}, {_requireFunctionCallSettingsExtraction: true}]
+            [{_lineBreakBeforeFunctionCallPrefix: true}, {}, {_requireFunctionCallSettingsExtraction: true}],
+            [{thoughts: "discourage"}, {}, {_requireFunctionCallSettingsExtraction: true}],
+            [{thoughts: "discourage", _lineBreakBeforeFunctionCallPrefix: true}, {}, {_requireFunctionCallSettingsExtraction: true}]
         ];
     }
 }

--- a/src/chatWrappers/generic/JinjaTemplateChatWrapper.ts
+++ b/src/chatWrappers/generic/JinjaTemplateChatWrapper.ts
@@ -671,7 +671,7 @@ export class JinjaTemplateChatWrapper extends ChatWrapper {
             return res;
         };
 
-        const validateThatAllMessageIdsAreUsed = (parts: ReturnType<typeof splitText<string[]>>) => {
+        const validateThatAllMessageIdsAreUsed = (parts: ReturnType<typeof splitText<string>>) => {
             const messageIdsLeft = new Set(messageIds);
 
             for (const part of parts) {

--- a/src/evaluator/LlamaChat/LlamaChat.ts
+++ b/src/evaluator/LlamaChat/LlamaChat.ts
@@ -24,6 +24,7 @@ import {LlamaSampler} from "../LlamaContext/LlamaSampler.js";
 import {LlamaModel} from "../LlamaModel/LlamaModel.js";
 import {getChatWrapperSegmentDefinition} from "../../utils/getChatWrapperSegmentDefinition.js";
 import {jsonDumps} from "../../chatWrappers/utils/jsonDumps.js";
+import {defaultMaxPreloadTokens} from "../LlamaChatSession/utils/LlamaChatSessionPromptCompletionEngine.js";
 import {
     eraseFirstResponseAndKeepFirstSystemChatContextShiftStrategy
 } from "./utils/contextShiftStrategies/eraseFirstResponseAndKeepFirstSystemChatContextShiftStrategy.js";
@@ -721,7 +722,7 @@ export class LlamaChat {
             onTextChunk,
             onToken,
             signal,
-            maxTokens = Math.min(256, Math.ceil(this.context.contextSize / 2)),
+            maxTokens = defaultMaxPreloadTokens(this.sequence),
             temperature,
             minP,
             topK,


### PR DESCRIPTION
### Description of change
* feat(`inspect gguf` command): format and print the Jinja chat template with `--key .chatTemplate`
* fix(`JinjaTemplateChatWrapper`): detect a different function call prefix for the first call in a response
* fix(`QwenChatWrapper`): improve Qwen chat template detection
* fix: adjust default prompt completion length based on SWA size when relevant
* fix: adapt to `llama.cpp` changes

Fixes #471 


### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply eslint formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits and pull request title follow conventions explained in [pull request guidelines](https://node-llama-cpp.withcat.ai/guide/contributing) (PRs that do not follow this convention will not be merged)