### PR TITLE
fix: adapt to breaking `llama.cpp` changes

### DIFF
--- a/llama/addon/AddonContext.cpp
+++ b/llama/addon/AddonContext.cpp
@@ -420,7 +420,8 @@ AddonContext::AddonContext(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Ad
         }
 
         if (options.Has("flashAttention")) {
-            context_params.flash_attn = options.Get("flashAttention").As<Napi::Boolean>().Value();
+            bool flashAttention = options.Get("flashAttention").As<Napi::Boolean>().Value();
+            context_params.flash_attn_type = flashAttention ? LLAMA_FLASH_ATTN_TYPE_ENABLED : LLAMA_FLASH_ATTN_TYPE_DISABLED;
         }
 
         if (options.Has("threads")) {


### PR DESCRIPTION
### Description of change
*  fix: use flash_attn_type instead of legacy flash_attn

<!--
  flash_attn option is no longer supported in latest llama.cpp
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all the following items:

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply eslint formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits and pull request title follow conventions explained in [pull request guidelines](https://node-llama-cpp.withcat.ai/guide/contributing) (PRs that do not follow this convention will not be merged)
