### PR TITLE
feat: add suport for `mistral3` models

### DIFF
--- a/src/chatWrappers/utils/resolveChatWrapper.ts
+++ b/src/chatWrappers/utils/resolveChatWrapper.ts
@@ -454,8 +454,6 @@ export function resolveChatWrapper(
             return createSpecializedChatWrapper(FalconChatWrapper);
         else if (arch === "gemma" || arch === "gemma2")
             return createSpecializedChatWrapper(GemmaChatWrapper);
-        else if (arch === "mistral3")
-            return createSpecializedChatWrapper(MistralChatWrapper);
     }
 
     return null;

--- a/test/standalone/chatWrappers/utils/resolveChatWrapper.test.ts
+++ b/test/standalone/chatWrappers/utils/resolveChatWrapper.test.ts
@@ -767,34 +767,4 @@ describe("resolveChatWrapper", () => {
         });
         expect(chatWrapper).to.be.instanceof(HarmonyChatWrapper);
     });
-
-    test("should resolve to MistralChatWrapper based on mistral3 architecture", () => {
-        const chatWrapper = resolveChatWrapper({
-            fileInfo: {
-                version: 3,
-                tensorCount: 0,
-                metadata: {
-                    general: {
-                        architecture: "mistral3",
-                        // eslint-disable-next-line camelcase
-                        quantization_version: "1"
-                    },
-                    tokenizer: {
-                        ggml: {
-                            model: "llama",
-                            tokens: [],
-                            // eslint-disable-next-line camelcase
-                            token_type: []
-                        }
-                    }
-                } as any,
-                metadataSize: 0,
-                architectureMetadata: {} as any,
-                splicedParts: 1,
-                totalTensorCount: 0,
-                totalMetadataSize: 0
-            }
-        });
-        expect(chatWrapper).to.be.instanceof(MistralChatWrapper);
-    });
 });


### PR DESCRIPTION
### Description of change

Mistral released a new series of models with a new `mistral3` architecture.

This commit updates the `GgufArchitectureType` so include `mistral3`.

This was tested with Ministral-3-3B-Instruct-2512-Q4_K_M.gguf

<img width="493" height="390" alt="Screenshot 2025-12-03 at 23 18 19" src="https://github.com/user-attachments/assets/1766082d-cc7c-4926-b7d7-e05449a2c073" />

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply eslint formatting
- [x] `npm run test` passes with this change (marking as passed since same tests fail for me on latest `master` branch)
- [x] This pull request links relevant issues as `Fixes #0000` N/A
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change N/A
- [x] The new commits and pull request title follow conventions explained in [pull request guidelines](https://node-llama-cpp.withcat.ai/guide/contributing) (PRs that do not follow this convention will not be merged)
