### PR TITLE
fix: OIDC package publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -555,6 +555,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
+      - name: Update npm
+        run: npm install -g npm@latest
       - name: Install modules
         run: npm ci
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
### Description of change
* fix: OIDC package publish

A newer npm version is needed for the publish to succeed. The `semantic-release` job worked because `semantic-release` has an updated npm version as a depepndency, but a publish outside of `semantic-release` failed because the npm version is too old.


### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply eslint formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits and pull request title follow conventions explained in [pull request guidelines](https://node-llama-cpp.withcat.ai/guide/contributing) (PRs that do not follow this convention will not be merged)
