### PR TITLE
fix: prevent grammar desync with harmony chat wrapper

### DIFF
--- a/src/evaluator/LlamaChat/LlamaChat.ts
+++ b/src/evaluator/LlamaChat/LlamaChat.ts
@@ -1692,6 +1692,7 @@ class GenerateResponseState<const Functions extends ChatModelFunctions | undefin
     };
     private readonly dryRepeatPenalty?: LLamaContextualDryRepeatPenalty;
     private readonly grammarEvaluationState: LlamaGrammarEvaluationState | undefined;
+    private readonly _initialGrammarEvaluationState: LlamaGrammarEvaluationState | undefined;
     private readonly functionNameGrammar?: FunctionCallNameGrammar<NonNullable<Functions>>;
     private functionsGrammar?: FunctionCallNameGrammar<NonNullable<Functions>> | FunctionCallParamsGrammar<NonNullable<Functions>>;
     private functionsEvaluationState: LlamaGrammarEvaluationState | undefined;
@@ -1866,6 +1867,7 @@ class GenerateResponseState<const Functions extends ChatModelFunctions | undefin
         this.grammarEvaluationState = this.grammar != null
             ? new LlamaGrammarEvaluationState({model: this.llamaChat.model, grammar: this.grammar})
             : undefined;
+        this._initialGrammarEvaluationState = this.grammarEvaluationState?.clone();
         this.functionNameGrammar = this.functionsEnabled
             ? new FunctionCallNameGrammar(this.llamaChat.model._llama, this.functions as NonNullable<Functions>, this.chatWrapper)
             : undefined;
@@ -2517,9 +2519,11 @@ class GenerateResponseState<const Functions extends ChatModelFunctions | undefin
                     await injectTokens(this.noPrefixTrigger.inject, true);
 
                     this.segmentHandler.openSegment(this.noPrefixTrigger.segmentType);
-                } else if (this.noPrefixTrigger?.type === "response")
+                } else if (this.noPrefixTrigger?.type === "response") {
+                    if (this.grammarEvaluationState != null && this._initialGrammarEvaluationState != null)
+                        this._initialGrammarEvaluationState._cloneInto(this.grammarEvaluationState);
                     await injectTokens(this.noPrefixTrigger.inject, true);
-                else
+                } else
                     this.streamRegulator.addChunk({
                         tokens: generatedTokens,
                         text: this.llamaChat.model.detokenize(generatedTokens, false, this.getLastTokens())

--- a/src/evaluator/LlamaGrammarEvaluationState.ts
+++ b/src/evaluator/LlamaGrammarEvaluationState.ts
@@ -18,7 +18,7 @@ export type LlamaGrammarEvaluationStateOptions = {
  */
 export class LlamaGrammarEvaluationState {
     /** @internal */ public readonly _llama: Llama;
-    /** @internal */ public readonly _state: AddonGrammarEvaluationState;
+    /** @internal */ public _state: AddonGrammarEvaluationState;
 
     public constructor(options: LlamaGrammarEvaluationStateOptions);
     public constructor(existingState: LlamaGrammarEvaluationState);
@@ -40,5 +40,13 @@ export class LlamaGrammarEvaluationState {
     /** Clone the grammar evaluation state */
     public clone(): LlamaGrammarEvaluationState {
         return new LlamaGrammarEvaluationState(this);
+    }
+
+    /** @internal */
+    public _cloneInto(other: LlamaGrammarEvaluationState) {
+        if (this._llama !== other._llama)
+            throw new Error("Cannot clone into a state from a different Llama instance");
+
+        other._state = new this._llama._bindings.AddonGrammarEvaluationState(this._state);
     }
 }

--- a/test/modelDependent/qwen3-0.6b/harmonyChatWrapperGrammar.test.ts
+++ b/test/modelDependent/qwen3-0.6b/harmonyChatWrapperGrammar.test.ts
@@ -1,0 +1,44 @@
+import {describe, expect, test} from "vitest";
+import {HarmonyChatWrapper, LlamaChatSession} from "../../../src/index.js";
+import {getModelFile} from "../../utils/modelFiles.js";
+import {getTestLlama} from "../../utils/getTestLlama.js";
+
+describe("qwen3 0.6b", () => {
+    describe("grammar", () => {
+        test("HarmonyChatWrapper grammar token dropping bug regression", {timeout: 1000 * 60 * 60 * 2}, async () => {
+            const modelPath = await getModelFile("Qwen3-0.6B-Q8_0.gguf");
+            const llama = await getTestLlama();
+            const model = await llama.loadModel({
+                modelPath
+            });
+            const context = await model.createContext({
+                contextSize: 2048
+            });
+            const chatWrapper = new HarmonyChatWrapper();
+            const chatSession = new LlamaChatSession({
+                contextSequence: context.getSequence(),
+                chatWrapper
+            });
+
+            const grammar = await llama.createGrammarForJsonSchema({
+                type: "object",
+                properties: {
+                    prop: {type: "string"}
+                },
+                required: ["prop"]
+            });
+
+            const promptTest = 'output this JSON string exactly and nothing else: {"prop":"test"}';
+            
+            const res = await chatSession.prompt(promptTest, {
+                grammar,
+                temperature: 0,
+                seed: 1
+            });
+            const parsedRes = grammar.parse(res);
+            
+            expect(res.trim().startsWith("{")).toBe(true);
+            expect(parsedRes).toHaveProperty("prop");
+        });
+    });
+});


### PR DESCRIPTION
fix: prevent grammar desync with harmony chat wrapper

rewind the grammar evaluation state when prefix triggers like HarmonyChatWrapper discard already sampled tokens, ensuring JSON grammars do not lose track of the first braces.

Closes: #575

### Description of change

This PR fixes a bug where `node-llama-cpp` drops the opening brackets of `LlamaJsonSchemaGrammar` evaluations when it is used alongside prefix-triggering models (like those leveraging the [HarmonyChatWrapper](https://github.com/withcatai/node-llama-cpp/blob/master/src/chatWrappers/HarmonyChatWrapper.ts:14:0-701:1) in `gpt-oss` architecture types).

**The Issue**: Previously, when the model generates its very first character (e.g. `{`), the [LlamaGrammarEvaluationState](https://github.com/withcatai/node-llama-cpp/blob/master/src/evaluator/LlamaGrammarEvaluationState.ts:18:0-51:1) successfully accepted it and advanced its internal evaluation state. However, the [HarmonyChatWrapper](https://github.com/withcatai/node-llama-cpp/blob/master/src/chatWrappers/HarmonyChatWrapper.ts:14:0-701:1) prefix trigger parsing mechanism would intercept this token, realize it doesn't match its `<|channel|>` channel tags format constraint, and then forcefully discard the sampled tokens to inject a clean `<|channel|>final<|message|>` start sequence instead. Because the tokens were discarded but the grammar state had irrevocably mutated, the final output would be pushed out-of-sync with the grammar parsing sequence—causing invalid partial strings like `"key":"value"}`.

**The Fix:** This PR implements a rewind mechanism. An internal snapshot (`_initialGrammarEvaluationState`) is captured when the response text loop is set up. Subsequently, if the `noPrefixTrigger` sequence engages on fallback and discards active tokens, we also refresh the global [grammarEvaluationState](https://github.com/withcatai/node-llama-cpp/blob/master/src/evaluator/LlamaChat/LlamaChat.ts:3099:12-3104:13) back to its original clean slate utilizing a new internal [_cloneInto](https://github.com/withcatai/node-llama-cpp/blob/master/src/evaluator/LlamaGrammarEvaluationState.ts:44:4-50:5) capability inside the state tracker, thus remaining entirely readonly but re-synchronizing correctly with the token stream. 

**Verification:** I've added a unit test within the Qwen 3 0.6B test suite that instantiates a [HarmonyChatWrapper](https://github.com/withcatai/node-llama-cpp/blob/master/src/chatWrappers/HarmonyChatWrapper.ts:14:0-701:1) mapped against a JSON Schema Grammar and verifies that the output correctly and robustly surfaces the leading bracket `{` natively despite the underlying chunk discards.


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply eslint formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits and pull request title follow conventions explained in [pull request guidelines](https://node-llama-cpp.withcat.ai/guide/contributing) (PRs that do not follow this convention will not be merged)
