### PR TITLE
fix: update cpu_get_num_math to common_cpu_get_num_math (llama.cpp rename)

### DIFF
--- a/llama/addon/AddonContext.cpp
+++ b/llama/addon/AddonContext.cpp
@@ -397,7 +397,7 @@ AddonContext::AddonContext(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Ad
 
     context_params = llama_context_default_params();
     context_params.n_ctx = 4096;
-    context_params.n_threads = std::max(cpu_get_num_math(), 1);
+    context_params.n_threads = std::max(common_cpu_get_num_math(), 1);
     context_params.n_threads_batch = context_params.n_threads;
     context_params.no_perf = true;
     context_params.swa_full = false;
@@ -745,7 +745,7 @@ Napi::Value AddonContext::SetThreads(const Napi::CallbackInfo& info) {
 
     const auto threads = info[0].As<Napi::Number>().Int32Value();
     const auto resolvedThreads = threads == 0
-        ? std::max((int32_t)std::thread::hardware_concurrency(), std::max(cpu_get_num_math(), 1))
+        ? std::max((int32_t)std::thread::hardware_concurrency(), std::max(common_cpu_get_num_math(), 1))
         : threads;
 
     if (llama_n_threads(ctx) != resolvedThreads) {

--- a/llama/addon/addon.cpp
+++ b/llama/addon/addon.cpp
@@ -51,7 +51,7 @@ Napi::Value addonGetSupportsMlock(const Napi::CallbackInfo& info) {
 }
 
 Napi::Value addonGetMathCores(const Napi::CallbackInfo& info) {
-    return Napi::Number::New(info.Env(), cpu_get_num_math());
+    return Napi::Number::New(info.Env(), common_cpu_get_num_math());
 }
 
 Napi::Value addonGetBlockSizeForGgmlType(const Napi::CallbackInfo& info) {


### PR DESCRIPTION
## Summary

After `npx node-llama-cpp source download --release latest --gpu metal`, the addon fails to compile with:

```
addon/AddonContext.cpp:400:41: error: use of undeclared identifier 'cpu_get_num_math'
addon/AddonContext.cpp:748:75: error: use of undeclared identifier 'cpu_get_num_math'
addon/addon.cpp:54:42:        error: use of undeclared identifier 'cpu_get_num_math'
```

Upstream llama.cpp renamed `cpu_get_num_math()` to `common_cpu_get_num_math()` in `common/common.h` as part of the `common_*` namespace pass. The function signature is unchanged.

This PR updates the three call sites in the addon to use the new name.

## Changes

- `llama/addon/AddonContext.cpp:400` — `cpu_get_num_math()` → `common_cpu_get_num_math()`
- `llama/addon/AddonContext.cpp:748` — `cpu_get_num_math()` → `common_cpu_get_num_math()`
- `llama/addon/addon.cpp:54` — `cpu_get_num_math()` → `common_cpu_get_num_math()`

## Related

This is one of three compile blockers when rebuilding the addon against current llama.cpp on macOS Sequoia (SDK 26.2). The other two — the `common` → `llama-common` library target rename and the `std::atomic_bool loaded = false;` deleted-copy-ctor — are addressed by #597 (@CreatiCoding). All three patches together produce a working build.

## Verification

Applied this patch plus #597 against `withcatai/node-llama-cpp@v3.18.1`, ran `npx node-llama-cpp source download --release latest --gpu metal` (resolved to llama.cpp `b9145`), and verified end-to-end on macOS 15.x arm64 with Metal:

| Model                                | Load | Generate |
|--------------------------------------|------|----------|
| Llama 3.2 3B Instruct Q4_K_M         | ✓    | ✓        |
| Qwen 2.5 7B Instruct Q4_K_M          | ✓    | ✓        |
| Gemma 4 E4B Instruct Q4_K_M          | ✓    | ✓        |

Gemma 4 specifically requires this rebuild path — the prebuilt llama.cpp `b8390` that ships with v3.18.1 predates Gemma 4 architecture support, so loading a Gemma 4 GGUF without rebuilding returns `unknown model architecture: 'gemma4'`.