### PR TITLE
feat(LlamaContext): expose kvUnified option

### DIFF
--- a/llama/addon/AddonContext.cpp
+++ b/llama/addon/AddonContext.cpp
@@ -460,6 +460,10 @@ AddonContext::AddonContext(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Ad
         if (options.Has("swaFullCache")) {
             context_params.swa_full = options.Get("swaFullCache").As<Napi::Boolean>().Value();
         }
+
+        if (options.Has("kvUnified")) {
+            context_params.kv_unified = options.Get("kvUnified").As<Napi::Boolean>().Value();
+        }
     }
 }
 AddonContext::~AddonContext() {

--- a/src/evaluator/LlamaContext/LlamaContext.ts
+++ b/src/evaluator/LlamaContext/LlamaContext.ts
@@ -81,6 +81,7 @@ export class LlamaContext {
     /** @internal */ private readonly _unusedSequenceIds: number[] = [];
     /** @internal */ private readonly _batchingOptions: Required<BatchingOptions>;
     /** @internal */ public readonly _swaFullCache: boolean = false;
+    /** @internal */ private readonly _kvUnified: boolean | undefined = undefined;
     /** @internal */ private readonly _queuedDecodeSequenceIds = new Set<number>();
     /** @internal */ private readonly _queuedDecodes: InternalQueuedDecode[] = [];
     /** @internal */ private readonly _disposeAggregator = new AsyncDisposeAggregator();
@@ -112,6 +113,7 @@ export class LlamaContext {
             itemPrioritizationStrategy: batchingItemsPrioritizationStrategy = "maximumParallelism"
         } = {},
         swaFullCache = _model.defaultContextSwaFullCache,
+        kvUnified,
         performanceTracking = false,
         experimentalKvCacheKeyType,
         experimentalKvCacheValueType,
@@ -155,6 +157,7 @@ export class LlamaContext {
         this._kvCacheKeyType = experimentalKvCacheKeyType;
         this._kvCacheValueType = experimentalKvCacheValueType;
         this._swaFullCache = !!swaFullCache;
+        this._kvUnified = kvUnified;
         this._ctx = new this._llama._bindings.AddonContext(this._model._model, removeNullFields({
             contextSize: padSafeContextSize(this._contextSize * this._totalSequences, "up"), // each sequence needs its own <contextSize> of cells
             batchSize: this._batchSize + (
@@ -170,7 +173,8 @@ export class LlamaContext {
             performanceTracking: this._performanceTracking,
             kvCacheKeyType: this._kvCacheKeyType,
             kvCacheValueType: this._kvCacheValueType,
-            swaFullCache: this._swaFullCache
+            swaFullCache: this._swaFullCache,
+            kvUnified: this._kvUnified
         }));
         this._batchingOptions = {
             dispatchSchedule: batchingDispatchSchedule,

--- a/src/evaluator/LlamaContext/types.ts
+++ b/src/evaluator/LlamaContext/types.ts
@@ -154,6 +154,21 @@ export type LlamaContextOptions = {
     swaFullCache?: boolean,
 
     /**
+     * Use a unified KV buffer shared across all sequences when computing attention.
+     *
+     * When enabled, llama.cpp uses a single contiguous KV buffer indexed by sequence id,
+     * which can significantly improve multi-sequence prefill/decode throughput on GPU
+     * backends by reducing per-sequence buffer juggling.
+     *
+     * The llama.cpp default for `kv_unified` depends on whether the number of sequences
+     * is auto-detected; explicitly setting `kvUnified: true` matches the behavior of
+     * `llama-server` running with `--kv-unified` (which is the default in many configurations).
+     *
+     * Defaults to the llama.cpp default for the context configuration.
+     */
+    kvUnified?: boolean,
+
+    /**
      * Load the provided LoRA adapters onto the context.
      * LoRA adapters are used to modify the weights of a pretrained model to adapt to new tasks or domains
      * without the need for extensive retraining from scratch.


### PR DESCRIPTION
## Summary

Adds a `kvUnified?: boolean` option on `LlamaContextOptions`, plumbing through to `llama_context_params.kv_unified` in llama.cpp.

When enabled, llama.cpp uses a single contiguous KV buffer indexed by sequence id rather than per-sequence buffers. On GPU backends (Metal, CUDA) this can significantly improve multi-sequence prefill/decode throughput by reducing per-sequence buffer juggling and enabling more efficient batched attention.

## Why

`llama-server` already exposes this toggle as `--kv-unified` and most multi-slot deployments turn it on. Without a corresponding option in `node-llama-cpp`, callers running a single LlamaContext with `sequences: N` can't reach the same configuration, even when the underlying model + hardware would clearly benefit. The option was reachable via `experimental*KvCache*Type` for the dtype controls but not for the unified-buffer flag itself.

## Plumbing

- `src/evaluator/LlamaContext/types.ts` — new `kvUnified?: boolean` option on `LlamaContextOptions` with full docstring (sibling to the existing `swaFullCache` field).
- `src/evaluator/LlamaContext/LlamaContext.ts` — `_kvUnified` member, constructor destructure, forwarded into the `AddonContext` options bag alongside `swaFullCache`, `kvCacheKeyType`, etc.
- `llama/addon/AddonContext.cpp` — when `options.Has("kvUnified")`, sets `context_params.kv_unified` to the unwrapped boolean.

## Compatibility

- `kvUnified` is optional. When unset, the existing default ("whatever llama.cpp picks for this configuration") is preserved exactly — `context_params.kv_unified` is not touched.
- No public-API breakage. Existing callers see no behavior shift.

## Test plan

- [x] Local build + smoke test against Qwen2.5-Coder-3B-Instruct Q4_K_M (Metal, contextSize=8192, sequences=8) with `kvUnified: true` — context constructs cleanly; per-decode logs confirm `kv_unified=1` reaches llama.cpp.
- [x] Existing tests pass locally.
- [ ] CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
