### PR TITLE
feat(LlamaContext): expose ubatchSize separately from batchSize

### DIFF
--- a/llama/addon/AddonContext.cpp
+++ b/llama/addon/AddonContext.cpp
@@ -414,6 +414,10 @@ AddonContext::AddonContext(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Ad
             context_params.n_ubatch = context_params.n_batch; // the batch queue is managed in the JS side, so there's no need for managing it on the C++ side
         }
 
+        if (options.Has("ubatchSize")) {
+            context_params.n_ubatch = options.Get("ubatchSize").As<Napi::Number>().Uint32Value();
+        }
+
         if (options.Has("sequences")) {
             context_params.n_seq_max = options.Get("sequences").As<Napi::Number>().Uint32Value();
         }

--- a/src/evaluator/LlamaContext/LlamaContext.ts
+++ b/src/evaluator/LlamaContext/LlamaContext.ts
@@ -105,6 +105,7 @@ export class LlamaContext {
         sequences,
         contextSize,
         batchSize,
+        ubatchSize,
         flashAttention = _model.defaultContextFlashAttention,
         threads,
         batching: {
@@ -162,6 +163,7 @@ export class LlamaContext {
                     ? 1 // +1 to handle edge cases with SWA KV cache
                     : 0
             ),
+            ubatchSize,
             sequences: this._totalSequences,
             flashAttention: this._flashAttention,
             threads: this._idealThreads,

--- a/src/evaluator/LlamaContext/types.ts
+++ b/src/evaluator/LlamaContext/types.ts
@@ -49,6 +49,20 @@ export type LlamaContextOptions = {
     batchSize?: number,
 
     /**
+     * The physical micro-batch size used inside the model's forward pass.
+     *
+     * Defaults to `batchSize` — the batch queue is managed JS-side and a
+     * single ubatch processes the whole batch. Set this lower than
+     * `batchSize` to chunk a large logical batch into smaller GPU
+     * submissions (matches llama.cpp's `--ubatch-size` flag, useful when
+     * the model is sensitive to per-ubatch VRAM peaks or when probing
+     * different `n_ubatch` values for throughput on a given hardware).
+     *
+     * Must be ≤ `batchSize`.
+     */
+    ubatchSize?: number,
+
+    /**
      * Flash attention is an optimization in the attention mechanism that makes inference faster, more efficient and uses less memory.
      *
      * The support for flash attention is currently experimental and may not always work as expected.


### PR DESCRIPTION
## Summary

Adds a `ubatchSize?: number` option on `LlamaContextOptions`, plumbing through to `llama_context_params.n_ubatch`. When unset, the existing default (`n_ubatch = n_batch`) is preserved exactly.

## Why

Today `llama/addon/AddonContext.cpp` always sets `n_ubatch = n_batch` inside the `batchSize` handler — the JS-side batch queue is the reason. That's a reasonable default, but it prevents callers from ever asking for a smaller physical micro-batch than the logical batch. The C++ value is the same one `llama-server` exposes as `--ubatch-size`, and decoupling them serves two real use cases:

1. **Per-ubatch VRAM headroom.** On hardware that's sensitive to VRAM peaks during the forward pass (some Metal models, low-end CUDA), a smaller `n_ubatch` lets a larger total `n_batch` fit. Today this is unreachable from `node-llama-cpp`.
2. **Throughput characterization.** Sweeping `n_ubatch` independently of `n_batch` is the canonical way to characterize a model+hardware combo for sustained-load deployments. Matches what `llama-server --batch-size N --ubatch-size M` already permits.

## Plumbing

- `src/evaluator/LlamaContext/types.ts` — new `ubatchSize?: number` field on `LlamaContextOptions` with docstring noting the `≤ batchSize` constraint and the link to llama.cpp's `--ubatch-size`.
- `src/evaluator/LlamaContext/LlamaContext.ts` — destructured from the options bag, forwarded into the `AddonContext` options.
- `llama/addon/AddonContext.cpp` — `if (options.Has("ubatchSize"))` overrides `context_params.n_ubatch`, placed AFTER the `batchSize` handler so the explicit value wins over the default.

## Compatibility

- `ubatchSize` is optional. When unset, `n_ubatch = n_batch` exactly as today.
- No public-API breakage.

## Test plan

- [x] Local build + smoke test on Qwen2.5-Coder-3B-Instruct Q4_K_M (Metal, `batchSize: 512`, `ubatchSize: 256`) — context constructs cleanly; per-decode logs confirm `n_ubatch=256` reaches llama.cpp.
- [x] Existing tests pass locally (no change with `ubatchSize` unset).
- [ ] CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
