### PR TITLE
fix: drain binding test child stdio

### DIFF
--- a/src/bindings/utils/testBindingBinary.ts
+++ b/src/bindings/utils/testBindingBinary.ts
@@ -129,9 +129,7 @@ export async function testBindingBinary(
         const subProcess = forkFunction.fork(__filename, [], {
             detached: false,
             silent: true,
-            stdio: pipeOutputOnNode
-                ? ["ignore", "pipe", "pipe", "ipc"]
-                : ["ignore", "ignore", "ignore", "ipc"],
+            stdio: ["ignore", "pipe", "pipe", "ipc"],
             env: {
                 ...process.env,
                 TEST_BINDING_CP: "true"
@@ -161,24 +159,22 @@ export async function testBindingBinary(
             onExit(subProcess.exitCode ?? -1);
         }
 
-        function onStdout(data: string) {
-            if (!pipeSet)
+        function onStdout(data: string | Buffer) {
+            if (!pipeOutputOnNode || !pipeSet)
                 return;
 
             process.stdout.write(data);
         }
 
-        function onStderr(data: string) {
-            if (!pipeSet)
+        function onStderr(data: string | Buffer) {
+            if (!pipeOutputOnNode || !pipeSet)
                 return;
 
             process.stderr.write(data);
         }
 
-        if (pipeOutputOnNode) {
-            subProcess.stdout?.on("data", onStdout);
-            subProcess.stderr?.on("data", onStderr);
-        }
+        subProcess.stdout?.on("data", onStdout);
+        subProcess.stderr?.on("data", onStderr);
 
         function pipeMessages() {
             if (!pipeOutputOnNode || pipeSet)


### PR DESCRIPTION
## Summary
- always pipe stdout/stderr for the Node binding-test child process
- drain those streams in the parent when logs are not requested
- preserve the existing behavior of only forwarding logs after the binary has loaded when `pipeOutputOnNode` is enabled

## Why
In an OpenClaw Debian 12 container with Intel Vulkan libraries installed, the Vulkan prebuilt addon can be imported directly and the GPU support check passes when the binding test child process uses piped stdio.

With the current default `stdio: ["ignore", "ignore", "ignore", "ipc"]`, the child exits before sending its initial `ready` IPC message, causing `getLlama()` to skip otherwise-working prebuilt binaries and fall back to building from source.

Piping and draining stdio in the parent avoids attaching the child to ignored/null fds while still discarding output by default.

## Validation
- `npm run test:typescript`
- `npm run lint:eslint -- src/bindings/utils/testBindingBinary.ts`
