### PR TITLE
fix: don't pipe stdin/stdout in spawnCommand under stdio MCP servers

### DIFF
--- a/src/utils/spawnCommand.ts
+++ b/src/utils/spawnCommand.ts
@@ -66,13 +66,17 @@ export function spawnCommand(
                 reject(createError(`Command ${getCommandString()} closed with code ${code}`));
         });
 
-        if (progressLogs) {
-            child.stdout?.pipe(process.stdout);
-            child.stderr?.pipe(process.stderr);
-            process.stdin.pipe(child.stdin!);
-        } else {
-            child.stderr?.pipe(process.stderr);
-        }
+        // Echo progress to stderr (not stdout) so that when node-llama-cpp is used inside a process
+        // that reserves stdout as a data channel (e.g. a stdio MCP server speaking JSON-RPC over stdout),
+        // build/progress output doesn't corrupt that channel. The child's stdout is still captured for
+        // the resolved result via the "data" handler below, so nothing is lost.
+        // `process.stdin` is intentionally not piped into the child: build commands don't read stdin, and
+        // piping it hands the parent's stdin to the child, which drains/closes it on child exit and makes
+        // the parent stop reading its own input (breaking stdio-based transports / causing an early exit).
+        if (progressLogs)
+            child.stdout?.pipe(process.stderr);
+
+        child.stderr?.pipe(process.stderr);
 
         child.stdout?.on("data", (data) => {
             stdout.push(data.toString());

--- a/test/standalone/utils/spawnCommand.test.ts
+++ b/test/standalone/utils/spawnCommand.test.ts
@@ -1,0 +1,43 @@
+import {describe, expect, test, vi} from "vitest";
+import {spawnCommand} from "../../../src/utils/spawnCommand.js";
+
+
+describe("utils", () => {
+    describe("spawnCommand", () => {
+        test("keeps the parent's stdout clean and doesn't hijack its stdin", async () => {
+            const marker = "node_llama_cpp_spawn_stdout_marker";
+
+            const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+            const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+            const stdinPipe = vi.spyOn(process.stdin, "pipe");
+
+            try {
+                const res = await spawnCommand(
+                    process.execPath,
+                    ["-e", `process.stdout.write(${JSON.stringify(marker)})`],
+                    process.cwd(),
+                    process.env,
+                    true
+                );
+
+                // the child's stdout is still captured in the resolved result
+                expect(res.stdout).to.include(marker);
+
+                // ...but it must not be echoed onto the parent's stdout (reserved for data channels like JSON-RPC)
+                const parentStdout = stdoutWrite.mock.calls.map((call) => String(call[0])).join("");
+                expect(parentStdout).to.not.include(marker);
+
+                // progress is echoed to stderr instead
+                const parentStderr = stderrWrite.mock.calls.map((call) => String(call[0])).join("");
+                expect(parentStderr).to.include(marker);
+
+                // and the parent's stdin must never be piped into the child
+                expect(stdinPipe).to.not.toHaveBeenCalled();
+            } finally {
+                stdoutWrite.mockRestore();
+                stderrWrite.mockRestore();
+                stdinPipe.mockRestore();
+            }
+        });
+    });
+});


### PR DESCRIPTION
### Description of change

`spawnCommand` (used for the `cmake`/build steps when downloading or building a backend) pipes the build child's `stdout` to `process.stdout` and pipes `process.stdin` into the child:

```ts
if (progressLogs) {
    child.stdout?.pipe(process.stdout);
    child.stderr?.pipe(process.stderr);
    process.stdin.pipe(child.stdin!);
}
```

When `node-llama-cpp` is used as a dependency **inside a stdio MCP server** (which speaks JSON-RPC over stdout/stdin), this breaks the transport:

- `child.stdout.pipe(process.stdout)` injects cmake/build output into the JSON-RPC response stream on stdout.
- `process.stdin.pipe(child.stdin)` hands the server's JSON-RPC **request** stream to the build child, which drains/closes it on exit — so the parent stops reading requests and exits `0`.

This change:

- Echoes progress to **stderr** instead of stdout, so stdout stays reserved for the data channel. The child's stdout is still captured for the resolved result via the existing `"data"` handler, so nothing is lost.
- Stops piping `process.stdin` into the child (build commands don't read stdin; that pipe was the stdin-hijack / early-exit cause).

This matches the direction discussed in #596. The one open design choice raised there was whether progress should go to stderr or through the library logger — I went with **stderr** as the minimal, transport-safe default; happy to reroute through the logger instead if you'd prefer.

Fixes #596

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply eslint formatting
- [ ] `npm run test` passes with this change — see note below
- [x] This pull request links relevant issues as `Fixes #596`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change — N/A (internal behavior, no public API/docs change)
- [x] The new commits and pull request title follow conventions explained in the pull request guidelines

> **Testing note:** `tsc --noEmit` (`test:typescript`) and `eslint .` both pass clean, and the new `test/standalone/utils/spawnCommand.test.ts` passes. In the full standalone suite 162/170 tests pass; the 8 failures are environmental on my setup — they call `getTestLlama()` / download a remote GGUF, and I installed with `--ignore-scripts` without building the native backend locally. They are unrelated to this change (which only touches `spawnCommand`). Happy to confirm a green full run if CI needs anything.
