### PR TITLE
build: fit CUDA prebuilt binary module size under limit

### DIFF
--- a/docs/blog/v3.19-gemma-4.md
+++ b/docs/blog/v3.19-gemma-4.md
@@ -1,6 +1,6 @@
 ---
 title: Gemma 4 is here!
-date: 2026-06-29T04:00:00Z
+date: 2026-06-29T17:00:00Z
 lastUpdated: false
 author:
     name: Gilad S.

--- a/llama/CMakeLists.txt
+++ b/llama/CMakeLists.txt
@@ -85,6 +85,31 @@ else()
     set(NLC_GGML_NATIVE ON)
 endif()
 
+if (DEFINED ENV{CI} AND ENV{CI} STREQUAL "true")
+    if (GGML_CUDA AND NOT DEFINED CMAKE_CUDA_ARCHITECTURES AND NOT NLC_GGML_NATIVE)
+        find_package(CUDAToolkit)
+        if (CUDAToolkit_VERSION VERSION_LESS "13")
+            list(APPEND CMAKE_CUDA_ARCHITECTURES 50-virtual 61-virtual 70-virtual)
+            list(APPEND CMAKE_CUDA_ARCHITECTURES 75-virtual 80-virtual 86-real)
+
+            if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL "11.8")
+                list(APPEND CMAKE_CUDA_ARCHITECTURES 89-real 90-virtual)
+            endif()
+
+            if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL "12.8")
+                list(APPEND CMAKE_CUDA_ARCHITECTURES 120a-real)
+            endif()
+            if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL "12.9")
+                list(APPEND CMAKE_CUDA_ARCHITECTURES 121a-real)
+            endif()
+
+            # Remove `90-virtual` due to low usage and because it inflates the binary size too much
+            list(REMOVE_ITEM CMAKE_CUDA_ARCHITECTURES 90-virtual)
+            message(STATUS "CUDAToolkit version: ${CUDAToolkit_VERSION}, setting CMAKE_CUDA_ARCHITECTURES to ${CMAKE_CUDA_ARCHITECTURES}")
+        endif()
+    endif()
+endif()
+
 add_subdirectory("llama.cpp")
 include_directories("llama.cpp")
 include_directories("./llama.cpp/common")


### PR DESCRIPTION
### Description of change
* build: fit CUDA prebuilt binary module size under limit


### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply eslint formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits and pull request title follow conventions explained in [pull request guidelines](https://node-llama-cpp.withcat.ai/guide/contributing) (PRs that do not follow this convention will not be merged)
