### PR TITLE
fix: pipe binding test output on Windows

### DIFF
--- a/src/bindings/getLlama.ts
+++ b/src/bindings/getLlama.ts
@@ -524,7 +524,7 @@ export async function getLlamaForOptions({
 }: LlamaOptions, {
     updateLastBuildInfoOnCompile = false,
     skipLlamaInit = false,
-    pipeBinaryTestErrorLogs = false
+    pipeBinaryTestErrorLogs = process.platform === "win32"
 }: {
     updateLastBuildInfoOnCompile?: boolean,
     skipLlamaInit?: boolean,

--- a/src/bindings/utils/testBindingBinary.ts
+++ b/src/bindings/utils/testBindingBinary.ts
@@ -20,7 +20,7 @@ export async function testBindingBinary(
     extBackendsPath: string | undefined,
     gpu: BuildGpu,
     testTimeout: number = 1000 * 60 * 5,
-    pipeOutputOnNode: boolean = false
+    pipeOutputOnNode: boolean = process.platform === "win32"
 ): Promise<boolean> {
     if (!detectedFileName.startsWith(expectedFileName)) {
         console.warn(

--- a/test/standalone/bindings/testBindingBinary.test.ts
+++ b/test/standalone/bindings/testBindingBinary.test.ts
@@ -1,0 +1,75 @@
+import {EventEmitter} from "node:events";
+import {afterEach, describe, expect, test, vi} from "vitest";
+
+const {forkMock} = vi.hoisted(() => ({forkMock: vi.fn()}));
+vi.mock("node:child_process", () => ({fork: forkMock}));
+
+import {testBindingBinary} from "../../../src/bindings/utils/testBindingBinary.js";
+
+function createFakeChildProcess() {
+    const child = new EventEmitter() as EventEmitter & {
+        exitCode: number | null,
+        killed: boolean,
+        stderr: EventEmitter,
+        stdout: EventEmitter,
+        kill(): void,
+        send(message: {type: string}): void
+    };
+
+    child.exitCode = null;
+    child.killed = false;
+    child.stderr = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.kill = () => {
+        child.killed = true;
+        child.exitCode = -1;
+    };
+    child.send = (message) => {
+        if (message.type === "start")
+            queueMicrotask(() => child.emit("message", {type: "loaded"}));
+        else if (message.type === "test")
+            queueMicrotask(() => child.emit("message", {type: "done"}));
+        else if (message.type === "exit") {
+            child.exitCode = 0;
+            queueMicrotask(() => child.emit("exit", 0));
+        }
+    };
+
+    return child;
+}
+
+describe("testBindingBinary", () => {
+    afterEach(() => forkMock.mockReset());
+
+    function setupFakeFork(forkOptions: {stdio?: unknown}[]) {
+        forkMock.mockImplementation((_file: string, _args: string[], options: {stdio: unknown}) => {
+            forkOptions.push(options);
+            const child = createFakeChildProcess();
+            queueMicrotask(() => child.emit("message", {type: "ready"}));
+            return child;
+        });
+    }
+
+    test("pipes child output by default on Windows", async () => {
+        const forkOptions: {stdio?: unknown}[] = [];
+        setupFakeFork(forkOptions);
+
+        await expect(testBindingBinary("fake-binding", undefined, false, 1000)).resolves.toBe(true);
+
+        expect(forkOptions).toHaveLength(1);
+        expect(forkOptions[0]?.stdio).toEqual(
+            process.platform === "win32"
+                ? ["ignore", "pipe", "pipe", "ipc"]
+                : ["ignore", "ignore", "ignore", "ipc"]
+        );
+    });
+
+    test("honors an explicit output pipe setting", async () => {
+        const forkOptions: {stdio?: unknown}[] = [];
+        setupFakeFork(forkOptions);
+
+        await expect(testBindingBinary("fake-binding", undefined, false, 1000, false)).resolves.toBe(true);
+
+        expect(forkOptions[0]?.stdio).toEqual(["ignore", "ignore", "ignore", "ipc"]);
+    });
+});


### PR DESCRIPTION
Fixes #638

On Windows, `fork()` with all stdio streams ignored can exit before the binding test child sends its `ready` message. This makes the Vulkan prebuilt binding appear unavailable and can trigger an unnecessary source build.

This change defaults the binding test's child output streams to pipes on Windows, and makes the public `getLlamaForOptions` path use the same platform-specific default. Explicit `pipeOutputOnNode` and `pipeBinaryTestErrorLogs` values still take precedence.

Added a mocked IPC regression test covering the Windows default and the explicit override.

Validation:
- `npm run test:typescript`
- `npm exec -- vitest run test/standalone/bindings/testBindingBinary.test.ts --reporter=verbose --pool=forks --maxWorkers=1`
- `npm run lint:eslint`
- `npm run format`
- `npm run build`
- `git diff --check`

The full standalone suite was attempted, but its local llama.cpp CMake/MSBuild build did not complete in this Windows environment; no external API or GPU service was used by the regression test.