### PR TITLE
docs: Vulkan build deps via distro packages on non-Ubuntu Linux (SPIRV-Headers)

### DIFF
--- a/docs/guide/Vulkan.md
+++ b/docs/guide/Vulkan.md
@@ -60,6 +60,19 @@ If you see `Vulkan used VRAM` in the output, it means that Vulkan support is wor
   ([ ! -f "$HOME/.zshrc" ] || grep -qxF "source /opt/vulkan-sdk/setup-env.sh" "$HOME/.zshrc") || (echo "source /opt/vulkan-sdk/setup-env.sh" >> "$HOME/.zshrc")
   source /opt/vulkan-sdk/setup-env.sh
   ```
+  >
+  #### Other Linux distributions: system packages {#vulkan-sdk-linux-packages}
+  Instead of the LunarG SDK, you can install your distribution's Vulkan build packages. You need CMake, Ninja, a `glslc`/shaderc compiler, and the Vulkan headers, loader, and **SPIRV-Headers**.
+  >
+  Verified on Arch Linux (including Asahi Linux on Apple Silicon):
+  ```shell
+  sudo pacman -S --needed cmake ninja vulkan-headers vulkan-icd-loader \
+                          shaderc spirv-headers spirv-tools vulkan-tools
+  ```
+  >
+  > **Note:** `spirv-headers` is a separate package from `spirv-tools` and is easy to miss. Without it, the build fails at CMake configure time with `Could not find a package configuration file provided by "SPIRV-Headers"`. Other distributions ship the same components under similar names (e.g. `vulkan-headers`, `vulkan-loader`/`libvulkan-dev`, `glslc`/`shaderc`, `spirv-headers`).
+  >
+  > On Apple Silicon under Asahi Linux there is no Vulkan SDK to install — the Apple GPU is exposed to Vulkan through Mesa's Honeykrisp driver (shipped with `mesa`), and the system packages above are all that's needed to build the Vulkan backend.
 
 * :::details Windows only: enable long paths support
   Open cmd as Administrator and run this command:


### PR DESCRIPTION
## What

The [Using Vulkan](https://node-llama-cpp.withcat.ai/guide/Vulkan) guide's
prerequisites only document installing the **LunarG Vulkan SDK** on **Windows**
and **Ubuntu**. This adds a **system-packages** path for other Linux
distributions, so users who build the Vulkan backend from source on non-Ubuntu
distros know exactly what to install.

## Why

Building with `--gpu vulkan` needs CMake, Ninja, a `glslc`/shaderc compiler, and
the Vulkan headers/loader **plus SPIRV-Headers**. On Arch-based systems (and
Asahi Linux on Apple Silicon), `spirv-headers` is a **separate package from
`spirv-tools`** and is easy to miss — without it the build fails at CMake
configure time with:

```
Could not find a package configuration file provided by "SPIRV-Headers"
```

That failure isn't obvious from the current docs, since the LunarG SDK bundles
SPIRV-Headers and the guide assumes it.

## Changes

`docs/guide/Vulkan.md` — under the Vulkan SDK prerequisite, add an
"Other Linux distributions: system packages" subsection with:

- A verified `pacman` command (Arch / Asahi).
- A note that `spirv-headers` ≠ `spirv-tools` and the exact CMake error when it's missing.
- A note that on Apple Silicon under Asahi Linux the GPU is exposed to Vulkan via
  Mesa's Honeykrisp driver (no SDK to install), so these system packages are all
  that's needed to build the Vulkan backend.

## Testing

Verified end-to-end on a MacBook Pro 14" (M2 Pro) running Asahi Linux: with these
packages, `node-llama-cpp source download --gpu vulkan` builds successfully and
`getLlama({ gpu: "vulkan" })` reports the Apple M2 Pro GPU with offloading enabled.

Docs-only change. I only listed package names I verified (Arch); happy to add
Fedora/openSUSE equivalents if you'd like, or adjust the placement/wording.
