### PR TITLE
docs: add milo to the awesome list

### DIFF
--- a/docs/guide/awesome.md
+++ b/docs/guide/awesome.md
@@ -27,6 +27,9 @@ import DataBadge from "../../.vitepress/components/DataBadge/DataBadge.vue";
 
 * [Manzoni](https://manzoni.app/) ([GitHub](https://github.com/gems-platforms/manzoni-app)) - a text editor running local LLMs
 
+* [Milo](https://milo.seemplifyai.com) ([GitHub](https://github.com/michaelegbo/milo)) - a speaking Three.js avatar with an optional local Node.js edition using node-llama-cpp for Qwen replies, alongside Kokoro speech and Whisper transcription
+  <br /><DataBadge title="Source available" content="PolyForm Noncommercial 1.0.0" href="https://github.com/michaelegbo/milo/blob/main/LICENSE"/>
+
 
 
 <br />


### PR DESCRIPTION
### Description of change

Add Milo to the Awesome list's Proprietary section. Milo is a speaking Three.js avatar whose
optional local Node.js edition uses `node-llama-cpp` for Qwen replies. Its
[README credits the runtime](https://github.com/michaelegbo/milo#license-and-credits), and the
[native implementation](https://github.com/michaelegbo/milo/blob/main/server/chat-worker.mjs)
loads models and creates chat sessions through `node-llama-cpp`.

The entry identifies the optional Node.js edition because the hosted browser edition uses
wllama. The source-available badge links to PolyForm Noncommercial 1.0.0; Milo is not presented
as OSI open source.

Validation: `npm run build`, `npm run format`, `git diff --check`, and the conventional PR title
check pass. All three links in the entry return HTTP 200. This change adds one entry only.
The changed page also passes VitePress Markdown rendering and Vue script/template compilation.

The full `npm run docs:build` did not complete locally on Windows: the default shell rejects
its POSIX `NODE_OPTIONS` assignment; a rerun through Git Bash was stopped during full-site
generation to keep this documentation-only check bounded. No full-site build success is claimed.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply eslint formatting
- [ ] `npm run test` passes with this change — N/A: documentation entry only; the full suite
  requires native models and runtime setup. No executable code changed.
- [ ] This pull request links relevant issues as `Fixes #0000` — N/A: no related issue
- [ ] There are new or updated unit tests validating the change — N/A: documentation entry only
- [x] Documentation has been updated to reflect this change
- [x] The proposed commit and PR title follow the
  [pull request guidelines](https://node-llama-cpp.withcat.ai/guide/contributing)
