### PR TITLE
fix(ci): wait for npm to serve the package before building electron examples

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -740,7 +740,7 @@ jobs:
       - release
     steps:
       - name: Approve documentation website deployment
-        uses: activescott/automate-environment-deployment-approval@v1.0.6
+        uses: activescott/automate-environment-deployment-approval@v2.1.0
         with:
           github_token: ${{ secrets.AUTO_APPROVAL_GITHUB_TOKEN }}
           environment_allow_list: "Documentation website"
@@ -791,6 +791,8 @@ jobs:
           NODE_LLAMA_CPP_SKIP_DOWNLOAD: true
         run: |
           npx --no vite-node ./scripts/scaffoldElectronExampleForCiBuild.ts --packageVersion "$DEPLOYED_PACKAGE_VERSION" --packageFolderPath ./electron-app-example
+          npx --no vite-node ./scripts/waitForNpmRegistryToHaveModuleVersion.ts --packageVersion "$DEPLOYED_PACKAGE_VERSION" --additionalWait 60 --timeoutMinutes 10
+
           cd electron-app-example
           npm install
 

--- a/scripts/waitForNpmRegistryToHaveModuleVersion.ts
+++ b/scripts/waitForNpmRegistryToHaveModuleVersion.ts
@@ -1,0 +1,70 @@
+import yargs from "yargs";
+import {hideBin} from "yargs/helpers";
+import {getCurrentNpmrcConfig, getNpmrcRegistry} from "../src/cli/utils/resolveNpmrcConfig.js";
+
+const npmrcConfig = await getCurrentNpmrcConfig();
+const npmRegistry = getNpmrcRegistry(npmrcConfig);
+const interval = 1000 * 5;
+const module = "node-llama-cpp";
+
+import "./packTemplates.js";
+
+const argv = await yargs(hideBin(process.argv))
+    .option("packageVersion", {
+        type: "string",
+        demandOption: true
+    })
+    .option("additionalWait", {
+        type: "number",
+        default: 60
+    })
+    .option("timeoutMinutes", {
+        type: "number",
+        default: 10
+    })
+    .argv;
+
+async function checkVersionExists(packageName: string, version: string): Promise<boolean> {
+    const response = await fetch(
+        npmRegistry.cleanRegistryUrl +
+        (
+            packageName
+                .split("/")
+                .map((item) => encodeURIComponent(item))
+                .join("/")
+        ) + `/${encodeURIComponent(version)}`
+    );
+
+    if (response.status === 404 || response.status === 500)
+        return false;
+    else if (response.status >= 200 && response.status < 300)
+        return true;
+    else if (!response.ok)
+        throw new Error(`Failed to fetch package info for ${packageName} from registry ${npmRegistry}`);
+
+    return false;
+}
+
+console.info(`Waiting for version ${module}@${argv.packageVersion} to appear in the registry for up to ${argv.timeoutMinutes} minutes...`);
+
+const startTime = Date.now();
+const maxEndTime = Date.now() + (1000 * 60 * argv.timeoutMinutes);
+while (Date.now() < maxEndTime) {
+    const exists = await checkVersionExists(module, argv.packageVersion);
+    if (exists) {
+        const timeDiff = Date.now() - startTime;
+        console.info(`Version ${module}@${argv.packageVersion} exists in the registry. Waited for ${timeDiff / 1000} seconds.`);
+
+        console.log(`Waiting an additional ${argv.additionalWait} seconds before exiting...`);
+        await new Promise((resolve) => setTimeout(resolve, argv.additionalWait * 1000));
+
+        console.log("Done waiting");
+        process.exit(0);
+        break;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, interval));
+}
+
+console.error(`Version ${module}@${argv.packageVersion} did not appear in the registry within ${argv.timeoutMinutes} minutes`);
+process.exit(1);

--- a/src/utils/gbnfJson/types.ts
+++ b/src/utils/gbnfJson/types.ts
@@ -62,14 +62,14 @@ export type GbnfJsonBasicStringSchema = {
 
     /**
      * When using `minLength` and/or `maxLength`,
-     * ensure to inform the model as part of the prompt what your expectations are regarding the length of the string.
+     * ensure to inform the model as part of the prompt or `description` what your expectations are regarding the length of the string.
      * Not doing this may lead to hallucinations.
      */
     readonly minLength?: number,
 
     /**
      * When using `minLength` and/or `maxLength`,
-     * ensure to inform the model as part of the prompt what your expectations are regarding the length of the string.
+     * ensure to inform the model as part of the prompt or `description` what your expectations are regarding the length of the string.
      * Not doing this may lead to hallucinations.
      */
     readonly maxLength?: number,
@@ -108,7 +108,8 @@ export type GbnfJsonObjectSchema<
      * Make sure you define `additionalProperties` for this to have any effect.
      *
      * When using `minProperties` and/or `maxProperties`,
-     * ensure to inform the model as part of the prompt what your expectations are regarding the number of keys in the object.
+     * ensure to inform the model as part of the prompt or `description`
+     * what your expectations are regarding the number of keys in the object.
      * Not doing this may lead to hallucinations.
      */
     readonly minProperties?: number,
@@ -117,7 +118,8 @@ export type GbnfJsonObjectSchema<
      * Make sure you define `additionalProperties` for this to have any effect.
      *
      * When using `minProperties` and/or `maxProperties`,
-     * ensure to inform the model as part of the prompt what your expectations are regarding the number of keys in the object.
+     * ensure to inform the model as part of the prompt or `description`
+     * what your expectations are regarding the number of keys in the object.
      * Not doing this may lead to hallucinations.
      */
     readonly maxProperties?: number,

--- a/test/modelDependent/functionary/functionaryModelGpuLayersOptions.test.ts
+++ b/test/modelDependent/functionary/functionaryModelGpuLayersOptions.test.ts
@@ -1549,8 +1549,8 @@ describe("functionary", () => {
                         });
                         expect(res.gpuLayers).to.be.gte(16);
                         expect(res.gpuLayers).to.be.lte(24);
-                        expect(res.gpuLayers).to.toMatchInlineSnapshot("17");
-                        expect(res.contextSize).to.toMatchInlineSnapshot("8192");
+                        expect(res.gpuLayers).to.toMatchInlineSnapshot("18");
+                        expect(res.contextSize).to.toMatchInlineSnapshot("6144");
                         expect(res.useMmap).to.toMatchInlineSnapshot("false");
                     }
                 });
@@ -1595,7 +1595,7 @@ describe("functionary", () => {
                         });
                         expect(res.gpuLayers).to.toMatchInlineSnapshot("9");
                         expect(res.contextSize).to.toMatchInlineSnapshot("7424");
-                        expect(res.useMmap).to.toMatchInlineSnapshot("true");
+                        expect(res.useMmap).to.toMatchInlineSnapshot("false");
                         expect(res.contextSize).to.be.gte(contextSize);
                     }
                     {
@@ -1690,7 +1690,7 @@ describe("functionary", () => {
                         });
                         expect(res.gpuLayers).to.toMatchInlineSnapshot("9");
                         expect(res.contextSize).to.toMatchInlineSnapshot("7424");
-                        expect(res.useMmap).to.toMatchInlineSnapshot("true");
+                        expect(res.useMmap).to.toMatchInlineSnapshot("false");
                         expect(res.contextSize).to.be.gte(contextSize);
                     }
                     {

--- a/test/modelDependent/stableCode/stableCodeModelGpuLayersOptions.test.ts
+++ b/test/modelDependent/stableCode/stableCodeModelGpuLayersOptions.test.ts
@@ -619,9 +619,9 @@ describe("stableCode", () => {
                         totalVram: s1GB * 2,
                         freeVram: s1GB * 1
                     });
-                    expect(res.gpuLayers).to.toMatchInlineSnapshot("8");
-                    expect(res.contextSize).to.toMatchInlineSnapshot("6144");
-                    expect(res.useMmap).to.toMatchInlineSnapshot("false");
+                    expect(res.gpuLayers).to.toMatchInlineSnapshot("0");
+                    expect(res.contextSize).to.toMatchInlineSnapshot("16384");
+                    expect(res.useMmap).to.toMatchInlineSnapshot("true");
                     expect(res.contextSize).to.be.gte(contextSize);
                 }
                 {
@@ -641,9 +641,9 @@ describe("stableCode", () => {
                         totalVram: s1GB * 1,
                         freeVram: s1GB * 1
                     });
-                    expect(res.gpuLayers).to.toMatchInlineSnapshot("6");
-                    expect(res.contextSize).to.toMatchInlineSnapshot("9984");
-                    expect(res.useMmap).to.toMatchInlineSnapshot("false");
+                    expect(res.gpuLayers).to.toMatchInlineSnapshot("0");
+                    expect(res.contextSize).to.toMatchInlineSnapshot("16384");
+                    expect(res.useMmap).to.toMatchInlineSnapshot("true");
                     expect(res.contextSize).to.be.gte(contextSize);
                 }
                 {


### PR DESCRIPTION
### Description of change
* fix: wait for npm to serve the package before building electron examples


### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply eslint formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits and pull request title follow conventions explained in [pull request guidelines](https://node-llama-cpp.withcat.ai/guide/contributing) (PRs that do not follow this convention will not be merged)
